### PR TITLE
Implement Apollo Axios Datasource

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,31 @@ const tokens2 = await authenticate({
 More documentation inside the packages:
 [@ovotech/keycloak-auth](packages/keycloak-auth/README.md)
 
+## AxiosDataSource for Apollo
+
+A rest datasource that uses axios under the hood. This allows adding generic interceptors, adapters etc.
+Integrates with cache and cache policies. Supports Interceptors.
+
+```bash
+yarn add @ovotech/apollo-datasource-axios
+```
+
+```typescript
+import { AxiosDataSource } from '@ovotech/apollo-datasource-axios';
+
+interface User {
+  name: string;
+}
+
+export class MyDataSource extends AxiosDataSource {
+  users(id: string) {
+    return this.get<User>(`/users/${id}`);
+  }
+}
+
+const dataSource = new MyDataSource({ baseURL: ..., });
+```
+
 ## Running the tests
 
 The tests require a running schema registry service, and we're using docker compose to start it, alongside kafka, zookeeper and postgres.

--- a/lerna.json
+++ b/lerna.json
@@ -1,16 +1,11 @@
-[{
+{
   "version": "1.0.6",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {
     "publish": {
-      "ignoreChanges": [
-        "*.md"
-      ]
+      "ignoreChanges": ["*.md"]
     }
   },
-  "packages": [
-    "packages/*"
-  ]
+  "packages": ["packages/*"]
 }
-]

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
-{
+[{
   "version": "1.0.6",
   "npmClient": "yarn",
   "useWorkspaces": true,
@@ -13,3 +13,4 @@
     "packages/*"
   ]
 }
+]

--- a/packages/apollo-datasource-axios/.npmignore
+++ b/packages/apollo-datasource-axios/.npmignore
@@ -1,0 +1,4 @@
+.*
+test/
+tsconfig.json
+tslint.json

--- a/packages/apollo-datasource-axios/LICENSE
+++ b/packages/apollo-datasource-axios/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2019 OVO Energy
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/apollo-datasource-axios/README.md
+++ b/packages/apollo-datasource-axios/README.md
@@ -1,7 +1,7 @@
 # AxiosDataSource for Apollo
 
-A rest datasource that uses axios under the hood. This allows adding generic interceptors, adaptors etc.
-Integrates with cache and cache policies.
+A rest datasource that uses axios under the hood. This allows adding generic interceptors, adapters etc.
+Integrates with cache and cache policies. Supports Interceptors.
 
 ### Using
 
@@ -27,7 +27,7 @@ const dataSource = new MyDataSource({ baseURL: ..., });
 
 ### Interceptors
 
-You can pass interceptors to axios declartivly with the `request: []` or `response: []` option keys, for request or response interceptors respectively.
+You can pass interceptors to axios declaratively with the `request: []` or `response: []` option keys, for request or response interceptors respectively.
 
 ```typescript
 const logResponse = (res) => {

--- a/packages/apollo-datasource-axios/README.md
+++ b/packages/apollo-datasource-axios/README.md
@@ -1,0 +1,77 @@
+# AxiosDataSource for Apollo
+
+A rest datasource that uses axios under the hood. This allows adding generic interceptors, adaptors etc.
+Integrates with cache and cache policies.
+
+### Using
+
+```bash
+yarn add @ovotech/apollo-datasource-axios
+```
+
+```typescript
+import { AxiosDataSource } from '@ovotech/apollo-datasource-axios';
+
+interface User {
+  name: string;
+}
+
+export class MyDataSource extends AxiosDataSource {
+  users(id: string) {
+    return this.get<User>(`/users/${id}`);
+  }
+}
+
+const dataSource = new MyDataSource({ baseURL: ..., });
+```
+
+### Interceptors
+
+You can pass interceptors to axios declartivly with the `request: []` or `response: []` option keys, for request or response interceptors respectively.
+
+```typescript
+const logResponse = (res) => {
+  console.log(res);
+  return res;
+}
+
+const logErr = (err) => {
+  console.log(err);
+  return err;
+}
+
+const dataSource = new MyDataSource(
+  { baseURL: ..., },
+  { response: [{ onFulfilled: logResponse, onRejected: logErr }]}
+);
+```
+
+## Running the tests
+
+You can run the tests with:
+
+```bash
+yarn test
+```
+
+### Coding style (linting, etc) tests
+
+Style is maintained with prettier and tslint
+
+```
+yarn lint
+```
+
+## Deployment
+
+Deployment is preferment by lerna automatically on merge / push to master, but you'll need to bump the package version numbers yourself. Only updated packages with newer versions will be pushed to the npm registry.
+
+## Contributing
+
+Have a bug? File an issue with a simple example that reproduces this so we can take a look & confirm.
+
+Want to make a change? Submit a PR, explain why it's useful, and make sure you've updated the docs (this file) and the tests (see [test folder](test)).
+
+## License
+
+This project is licensed under Apache 2 - see the [LICENSE](LICENSE) file for details

--- a/packages/apollo-datasource-axios/package.json
+++ b/packages/apollo-datasource-axios/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "@types/axios": "^0.14.0",
+    "@types/graphql": "^14.2.0",
     "@types/http-cache-semantics": "^4.0.0",
     "@types/jest": "^24.0.11",
     "@types/nock": "^9.3.1",

--- a/packages/apollo-datasource-axios/package.json
+++ b/packages/apollo-datasource-axios/package.json
@@ -27,7 +27,6 @@
     "jest": "^24.5.0",
     "nock": "^10.0.6",
     "prettier": "^1.16.4",
-    "stream-mock": "^1.2.0",
     "tslint": "^5.14.0",
     "tslint-config-prettier": "^1.18.0",
     "typescript": "^3.3.4000"

--- a/packages/apollo-datasource-axios/package.json
+++ b/packages/apollo-datasource-axios/package.json
@@ -18,13 +18,11 @@
     "build": "tsc --outDir dist --declaration"
   },
   "devDependencies": {
-    "@types/axios": "^0.14.0",
     "@types/graphql": "^14.2.0",
     "@types/http-cache-semantics": "^4.0.0",
     "@types/jest": "^24.0.11",
     "@types/nock": "^9.3.1",
     "@types/node": "^11.11.4",
-    "avsc": "^5.4.7",
     "graphql": "^14.2.1",
     "jest": "^24.5.0",
     "nock": "^10.0.6",

--- a/packages/apollo-datasource-axios/package.json
+++ b/packages/apollo-datasource-axios/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@ovotech/apollo-datasource-axios",
+  "description": "Datasource using axios",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "source": "src/index.ts",
+  "types": "dist/index.d.ts",
+  "author": "Ivan Kerin <ikerin@gmail.com>",
+  "license": "Apache-2.0",
+  "peerDependencies": {
+    "axios": "*"
+  },
+  "scripts": {
+    "test": "jest --runInBand",
+    "lint-prettier": "prettier --list-different {src,test}/**/*.ts",
+    "lint-tslint": "tslint --config tslint.json '{src,test}/**/*.ts'",
+    "lint": "yarn lint-prettier && yarn lint-tslint",
+    "build": "tsc --outDir dist --declaration"
+  },
+  "devDependencies": {
+    "@types/axios": "^0.14.0",
+    "@types/http-cache-semantics": "^4.0.0",
+    "@types/jest": "^24.0.11",
+    "@types/nock": "^9.3.1",
+    "@types/node": "^11.11.4",
+    "avsc": "^5.4.7",
+    "graphql": "^14.2.1",
+    "jest": "^24.5.0",
+    "nock": "^10.0.6",
+    "prettier": "^1.16.4",
+    "stream-mock": "^1.2.0",
+    "tslint": "^5.14.0",
+    "tslint-config-prettier": "^1.18.0",
+    "typescript": "^3.3.4000"
+  },
+  "jest": {
+    "preset": "../../jest-preset.json"
+  },
+  "dependencies": {
+    "apollo-datasource": "^0.3.1",
+    "apollo-server-caching": "^0.3.1",
+    "apollo-server-errors": "^2.2.1",
+    "axios": "^0.18.0",
+    "http-cache-semantics": "^4.0.3"
+  }
+}

--- a/packages/apollo-datasource-axios/src/AxiosDataSource.ts
+++ b/packages/apollo-datasource-axios/src/AxiosDataSource.ts
@@ -1,0 +1,89 @@
+import { DataSource, DataSourceConfig } from 'apollo-datasource';
+import { ApolloError, AuthenticationError, ForbiddenError } from 'apollo-server-errors';
+import axios, { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
+import { cacheAdapter } from './cacheAdapter';
+
+export interface RequestInterceptor<V = AxiosRequestConfig> {
+  onFulfilled?: (value: V) => V | Promise<V>;
+  onRejected?: (error: any) => any;
+}
+export interface ResponseInterceptor<V = AxiosResponse> {
+  onFulfilled?: (value: V) => V | Promise<V>;
+  onRejected?: (error: any) => any;
+}
+
+export abstract class AxiosDataSource<TContext = any> extends DataSource {
+  api: AxiosInstance;
+
+  constructor(
+    protected config: AxiosRequestConfig = {},
+    options?: { request?: RequestInterceptor[]; response?: ResponseInterceptor[] },
+  ) {
+    super();
+    this.api = axios.create(config);
+    if (options) {
+      const { request, response } = options;
+      if (request) {
+        request.forEach(({ onFulfilled, onRejected }) => this.api.interceptors.request.use(onFulfilled, onRejected));
+      }
+      if (response) {
+        response.forEach(({ onFulfilled, onRejected }) => this.api.interceptors.response.use(onFulfilled, onRejected));
+      }
+    }
+  }
+
+  initialize(config: DataSourceConfig<TContext>): void {
+    this.api.defaults.adapter = cacheAdapter(config.cache, this.api.defaults.adapter!);
+  }
+
+  async request<T = any>(config: AxiosRequestConfig) {
+    try {
+      return await this.api.request<T>(config);
+    } catch (error) {
+      if (error.response) {
+        const {
+          status,
+          statusText,
+          config: { url },
+          data,
+        } = (error as AxiosError).response!;
+
+        const message = `${status}: ${statusText}`;
+        if (error.response.status === 401) {
+          throw new AuthenticationError(message);
+        }
+        if (error.response.status === 403) {
+          throw new ForbiddenError(message);
+        }
+
+        throw new ApolloError(message, error.code, { response: { url, status, statusText, data } });
+      } else {
+        throw error;
+      }
+    }
+  }
+
+  get<T = any>(url: string, config?: AxiosRequestConfig) {
+    return this.request<T>({ url, method: 'get', ...config });
+  }
+
+  delete(url: string, config?: AxiosRequestConfig) {
+    return this.request({ url, method: 'delete', ...config });
+  }
+
+  head(url: string, config?: AxiosRequestConfig) {
+    return this.request({ url, method: 'head', ...config });
+  }
+
+  post<T = any>(url: string, data?: any, config?: AxiosRequestConfig) {
+    return this.request<T>({ url, data, method: 'head', ...config });
+  }
+
+  put<T = any>(url: string, data?: any, config?: AxiosRequestConfig) {
+    return this.request<T>({ url, data, method: 'put', ...config });
+  }
+
+  patch<T = any>(url: string, data?: any, config?: AxiosRequestConfig) {
+    return this.request<T>({ url, data, method: 'patch', ...config });
+  }
+}

--- a/packages/apollo-datasource-axios/src/AxiosDataSource.ts
+++ b/packages/apollo-datasource-axios/src/AxiosDataSource.ts
@@ -12,7 +12,7 @@ export interface ResponseInterceptor<V = AxiosResponse> {
   onRejected?: (error: any) => any;
 }
 
-export abstract class AxiosDataSource<TContext = any> extends DataSource {
+export abstract class AxiosDataSource<TContext = any, AdditonalAxiosRequestConfig = any> extends DataSource {
   api: AxiosInstance;
 
   constructor(
@@ -36,7 +36,7 @@ export abstract class AxiosDataSource<TContext = any> extends DataSource {
     this.api.defaults.adapter = cacheAdapter(config.cache, this.api.defaults.adapter!);
   }
 
-  async request<T = any>(config: AxiosRequestConfig) {
+  async request<T = any>(config: AxiosRequestConfig & AdditonalAxiosRequestConfig) {
     try {
       return await this.api.request<T>(config);
     } catch (error) {
@@ -65,27 +65,29 @@ export abstract class AxiosDataSource<TContext = any> extends DataSource {
     }
   }
 
-  get<T = any>(url: string, config?: AxiosRequestConfig) {
-    return this.request<T>({ url, method: 'get', ...config });
+  get<T = any>(url: string, config?: AxiosRequestConfig & AdditonalAxiosRequestConfig) {
+    return this.request<T>({ url, method: 'get', ...config } as AxiosRequestConfig & AdditonalAxiosRequestConfig);
   }
 
-  delete(url: string, config?: AxiosRequestConfig) {
-    return this.request({ url, method: 'delete', ...config });
+  delete(url: string, config?: AxiosRequestConfig & AdditonalAxiosRequestConfig) {
+    return this.request({ url, method: 'delete', ...config } as AxiosRequestConfig & AdditonalAxiosRequestConfig);
   }
 
-  head(url: string, config?: AxiosRequestConfig) {
-    return this.request({ url, method: 'head', ...config });
+  head(url: string, config?: AxiosRequestConfig & AdditonalAxiosRequestConfig) {
+    return this.request({ url, method: 'head', ...config } as AxiosRequestConfig & AdditonalAxiosRequestConfig);
   }
 
-  post<T = any>(url: string, data?: any, config?: AxiosRequestConfig) {
-    return this.request<T>({ url, data, method: 'post', ...config });
+  post<T = any>(url: string, data?: any, config?: AxiosRequestConfig & AdditonalAxiosRequestConfig) {
+    return this.request<T>({ url, data, method: 'post', ...config } as AxiosRequestConfig &
+      AdditonalAxiosRequestConfig);
   }
 
-  put<T = any>(url: string, data?: any, config?: AxiosRequestConfig) {
-    return this.request<T>({ url, data, method: 'put', ...config });
+  put<T = any>(url: string, data?: any, config?: AxiosRequestConfig & AdditonalAxiosRequestConfig) {
+    return this.request<T>({ url, data, method: 'put', ...config } as AxiosRequestConfig & AdditonalAxiosRequestConfig);
   }
 
-  patch<T = any>(url: string, data?: any, config?: AxiosRequestConfig) {
-    return this.request<T>({ url, data, method: 'patch', ...config });
+  patch<T = any>(url: string, data?: any, config?: AxiosRequestConfig & AdditonalAxiosRequestConfig) {
+    return this.request<T>({ url, data, method: 'patch', ...config } as AxiosRequestConfig &
+      AdditonalAxiosRequestConfig);
   }
 }

--- a/packages/apollo-datasource-axios/src/cacheAdapter.ts
+++ b/packages/apollo-datasource-axios/src/cacheAdapter.ts
@@ -1,0 +1,38 @@
+import { KeyValueCache } from 'apollo-server-caching';
+import { AxiosAdapter, AxiosRequestConfig, AxiosResponse } from 'axios';
+import * as CachePolicy from 'http-cache-semantics';
+import { URLSearchParams } from 'url';
+
+const cacheKey = ({ method, url, params }: AxiosRequestConfig) => {
+  return `${method}:${url}:${new URLSearchParams(params).toString()}`;
+};
+
+const serialize = ({ data, headers, status, statusText }: AxiosResponse, policy: CachePolicy) => {
+  return JSON.stringify({ data, headers, status, statusText, policy: policy.toObject() });
+};
+
+const deserialize = (config: AxiosRequestConfig, entry: string): [AxiosResponse, CachePolicy] => {
+  const { data, headers, status, statusText, policy } = JSON.parse(entry);
+  return [{ data, headers, status, statusText, config }, CachePolicy.fromObject(policy)];
+};
+
+export const cacheAdapter = (cache: KeyValueCache, adapter: AxiosAdapter) => async (config: AxiosRequestConfig) => {
+  const { url, method, headers } = config;
+  const newRequest = { url, method: String(method).toUpperCase(), headers };
+  const key = cacheKey(config);
+  const cached = await cache.get(key);
+
+  if (cached) {
+    const [cachedResponse, cachedPolicy] = deserialize(config, cached);
+    if (cachedPolicy.satisfiesWithoutRevalidation(newRequest)) {
+      return { ...cachedResponse, headers: cachedPolicy.responseHeaders() };
+    }
+  }
+
+  const newResponse = await adapter(config);
+  const newPolicy = new CachePolicy(newRequest, newResponse);
+  if (newPolicy.storable()) {
+    cache.set(key, serialize(newResponse, newPolicy), { ttl: newPolicy.timeToLive() });
+  }
+  return newResponse;
+};

--- a/packages/apollo-datasource-axios/test/TestDataSource.ts
+++ b/packages/apollo-datasource-axios/test/TestDataSource.ts
@@ -1,7 +1,12 @@
+import { AxiosRequestConfig } from 'axios';
 import { AxiosDataSource } from '../src/AxiosDataSource';
 
-export class TestDataSource extends AxiosDataSource {
+interface AdditionalConfig {
+  dataSourceVersion: string;
+}
+
+export class TestDataSource extends AxiosDataSource<any, AdditionalConfig> {
   users(id: string) {
-    return this.get(`/users/${id}`);
+    return this.get(`/users/${id}`, { dataSourceVersion: 'test' });
   }
 }

--- a/packages/apollo-datasource-axios/test/TestDataSource.ts
+++ b/packages/apollo-datasource-axios/test/TestDataSource.ts
@@ -1,0 +1,7 @@
+import { AxiosDataSource } from '../src/AxiosDataSource';
+
+export class TestDataSource extends AxiosDataSource {
+  users(id: string) {
+    return this.get(`/users/${id}`);
+  }
+}

--- a/packages/apollo-datasource-axios/test/integration.spec.ts
+++ b/packages/apollo-datasource-axios/test/integration.spec.ts
@@ -1,0 +1,83 @@
+import { InMemoryLRUCache } from 'apollo-server-caching';
+import * as nock from 'nock';
+import { TestDataSource } from './TestDataSource';
+import { RequestInterceptor } from '../src/AxiosDataSource';
+import { AxiosRequestConfig } from 'axios';
+import { ApolloError } from 'apollo-server-errors';
+
+const api = nock('http://api.example.com');
+const cache = new InMemoryLRUCache();
+const config = { context: {}, cache: cache as any };
+const dataSource = new TestDataSource({ baseURL: 'http://api.example.com' });
+dataSource.initialize(config);
+
+describe('Integration test', () => {
+  beforeEach(() => cache.flush());
+  it('Test cached event', async () => {
+    api.get('/users/12').reply(200, { id: 12, name: 'John' });
+    const user = await dataSource.users('12');
+
+    expect(user.status).toEqual(200);
+    expect(user.data).toEqual({ id: 12, name: 'John' });
+    expect(cache.getTotalSize()).resolves.toBeGreaterThan(0);
+  });
+
+  it('Test cache set and retrieve', async () => {
+    nock('http://api.example.com')
+      .get('/users/12')
+      .reply(200, { id: 12, name: 'John' }, { 'Cache-Control': 'max-age=1' });
+
+    nock('http://api.example.com')
+      .get('/users/12')
+      .reply(200, { id: 12, name: 'Other' }, { 'Cache-Control': 'max-age=1' });
+
+    const user1 = await dataSource.users('12');
+    const user2 = await dataSource.users('12');
+
+    await new Promise(resolve => setTimeout(resolve, 1200));
+
+    const user3 = await dataSource.users('12');
+
+    expect(user1.status).toEqual(200);
+    expect(user1.data).toEqual({ id: 12, name: 'John' });
+
+    expect(user2.status).toEqual(200);
+    expect(user2.data).toEqual({ id: 12, name: 'John' });
+
+    expect(user3.status).toEqual(200);
+    expect(user3.data).toEqual({ id: 12, name: 'Other' });
+  });
+
+  it('Test interceptors', async () => {
+    api.get('/users/12').reply(200, { id: 12, name: 'John' });
+
+    const req = {
+      onFulfilled: jest.fn().mockImplementation(cfg => cfg),
+      onRejected: jest.fn().mockImplementation(err => err),
+    };
+
+    const res = {
+      onFulfilled: jest.fn().mockImplementation(response => response),
+      onRejected: jest.fn().mockImplementation(err => err),
+    };
+
+    nock('http://api.example.com')
+      .get('/users/12')
+      .reply(200, { id: 12, name: 'Other' });
+
+    nock('http://api.example.com')
+      .get('/users/13')
+      .reply(404);
+
+    const intercepted = new TestDataSource({ baseURL: 'http://api.example.com' }, { request: [req], response: [res] });
+    intercepted.initialize(config);
+
+    await expect(intercepted.users('12')).resolves.toHaveProperty('status', 200);
+    await expect(intercepted.users('13')).resolves.toEqual(new ApolloError('Request failed with status code 404'));
+
+    expect(req.onFulfilled).toHaveBeenCalled();
+    expect(res.onFulfilled).toHaveBeenCalled();
+
+    expect(res.onRejected).toHaveBeenCalled();
+  });
+});

--- a/packages/apollo-datasource-axios/test/integration.spec.ts
+++ b/packages/apollo-datasource-axios/test/integration.spec.ts
@@ -1,9 +1,8 @@
 import { InMemoryLRUCache } from 'apollo-server-caching';
-import { ApolloError } from 'apollo-server-errors';
+import { ApolloError, AuthenticationError, ForbiddenError } from 'apollo-server-errors';
 import * as nock from 'nock';
 import { TestDataSource } from './TestDataSource';
 
-const api = nock('http://api.example.com');
 const cache = new InMemoryLRUCache();
 const config = { context: {}, cache: cache as any };
 const dataSource = new TestDataSource({ baseURL: 'http://api.example.com' });
@@ -12,7 +11,10 @@ dataSource.initialize(config);
 describe('Integration test', () => {
   beforeEach(() => cache.flush());
   it('Test cached event', async () => {
-    api.get('/users/12').reply(200, { id: 12, name: 'John' });
+    nock('http://api.example.com')
+      .get('/users/12')
+      .reply(200, { id: 12, name: 'John' });
+
     const user = await dataSource.users('12');
 
     expect(user.status).toEqual(200);
@@ -22,32 +24,36 @@ describe('Integration test', () => {
 
   it('Test cache set and retrieve', async () => {
     nock('http://api.example.com')
-      .get('/users/12')
-      .reply(200, { id: 12, name: 'John' }, { 'Cache-Control': 'max-age=1' });
+      .get('/users/13')
+      .reply(200, { id: 13, name: 'John' }, { 'Cache-Control': 'max-age=1' })
+      .get('/users/13')
+      .reply(200, { id: 13, name: 'Other' }, { 'Cache-Control': 'max-age=1' });
 
-    nock('http://api.example.com')
-      .get('/users/12')
-      .reply(200, { id: 12, name: 'Other' }, { 'Cache-Control': 'max-age=1' });
-
-    const user1 = await dataSource.users('12');
-    const user2 = await dataSource.users('12');
+    const user1 = await dataSource.users('13');
+    const user2 = await dataSource.users('13');
 
     await new Promise(resolve => setTimeout(resolve, 1200));
 
-    const user3 = await dataSource.users('12');
+    const user3 = await dataSource.users('13');
 
     expect(user1.status).toEqual(200);
-    expect(user1.data).toEqual({ id: 12, name: 'John' });
+    expect(user1.data).toEqual({ id: 13, name: 'John' });
 
     expect(user2.status).toEqual(200);
-    expect(user2.data).toEqual({ id: 12, name: 'John' });
+    expect(user2.data).toEqual({ id: 13, name: 'John' });
 
     expect(user3.status).toEqual(200);
-    expect(user3.data).toEqual({ id: 12, name: 'Other' });
+    expect(user3.data).toEqual({ id: 13, name: 'Other' });
   });
 
   it('Test interceptors', async () => {
-    api.get('/users/12').reply(200, { id: 12, name: 'John' });
+    nock('http://api.example.com')
+      .get('/users/14')
+      .reply(200, { id: 14, name: 'John' })
+      .get('/users/14')
+      .reply(200, { id: 14, name: 'Other' })
+      .get('/users/15')
+      .reply(404);
 
     const req = {
       onFulfilled: jest.fn().mockImplementation(cfg => cfg),
@@ -59,23 +65,83 @@ describe('Integration test', () => {
       onRejected: jest.fn().mockImplementation(err => err),
     };
 
-    nock('http://api.example.com')
-      .get('/users/12')
-      .reply(200, { id: 12, name: 'Other' });
-
-    nock('http://api.example.com')
-      .get('/users/13')
-      .reply(404);
-
-    const intercepted = new TestDataSource({ baseURL: 'http://api.example.com' }, { request: [req], response: [res] });
+    const intercepted = new TestDataSource(undefined, { request: [req], response: [res] });
     intercepted.initialize(config);
 
-    await expect(intercepted.users('12')).resolves.toHaveProperty('status', 200);
-    await expect(intercepted.users('13')).resolves.toEqual(new ApolloError('Request failed with status code 404'));
+    await expect(intercepted.get('http://api.example.com/users/14')).resolves.toHaveProperty('status', 200);
+    await expect(intercepted.get('http://api.example.com/users/15')).resolves.toEqual(
+      new ApolloError('Request failed with status code 404'),
+    );
 
     expect(req.onFulfilled).toHaveBeenCalled();
     expect(res.onFulfilled).toHaveBeenCalled();
 
     expect(res.onRejected).toHaveBeenCalled();
+  });
+
+  it('Test AuthenticationError', async () => {
+    nock('http://api.example.com')
+      .get('/users/16')
+      .reply(401, { message: 'unknown user' });
+
+    await expect(dataSource.users('16')).rejects.toBeInstanceOf(AuthenticationError);
+  });
+
+  it('Test ForbiddenError', async () => {
+    nock('http://api.example.com')
+      .get('/users/17')
+      .reply(403, { message: 'unknown user' });
+
+    await expect(dataSource.users('17')).rejects.toBeInstanceOf(ForbiddenError);
+  });
+
+  it('Test ApolloError', async () => {
+    nock('http://api.example.com')
+      .get('/users/18')
+      .reply(500, { message: 'unknown' });
+
+    const result = dataSource.users('18');
+    await expect(result).rejects.toBeInstanceOf(ApolloError);
+    await expect(result).rejects.toHaveProperty(
+      'extensions',
+      expect.objectContaining({
+        response: {
+          url: 'http://api.example.com/users/18',
+          status: 500,
+          statusText: null,
+          data: { message: 'unknown' },
+        },
+      }),
+    );
+  });
+
+  it('Test methods', async () => {
+    nock('http://api.example.com')
+      .post('/users/19', { test: 'post' })
+      .reply(200, { message: 'post' });
+
+    nock('http://api.example.com')
+      .head('/users/20')
+      .reply(200);
+
+    nock('http://api.example.com')
+      .put('/users/21', { test: 'put' })
+      .reply(200, { message: 'put' });
+
+    nock('http://api.example.com')
+      .patch('/users/22', { test: 'patch' })
+      .reply(200, { message: 'patch' });
+
+    nock('http://api.example.com')
+      .delete('/users/23')
+      .reply(200, { message: 'delete' });
+
+    await expect(dataSource.post('/users/19', { test: 'post' })).resolves.toHaveProperty('data', { message: 'post' });
+    await expect(dataSource.head('/users/20')).resolves.toHaveProperty('status', 200);
+    await expect(dataSource.put('/users/21', { test: 'put' })).resolves.toHaveProperty('data', { message: 'put' });
+    await expect(dataSource.patch('/users/22', { test: 'patch' })).resolves.toHaveProperty('data', {
+      message: 'patch',
+    });
+    await expect(dataSource.delete('/users/23')).resolves.toHaveProperty('status', 200);
   });
 });

--- a/packages/apollo-datasource-axios/test/integration.spec.ts
+++ b/packages/apollo-datasource-axios/test/integration.spec.ts
@@ -1,9 +1,7 @@
 import { InMemoryLRUCache } from 'apollo-server-caching';
+import { ApolloError } from 'apollo-server-errors';
 import * as nock from 'nock';
 import { TestDataSource } from './TestDataSource';
-import { RequestInterceptor } from '../src/AxiosDataSource';
-import { AxiosRequestConfig } from 'axios';
-import { ApolloError } from 'apollo-server-errors';
 
 const api = nock('http://api.example.com');
 const cache = new InMemoryLRUCache();

--- a/packages/apollo-datasource-axios/tsconfig.json
+++ b/packages/apollo-datasource-axios/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/apollo-datasource-axios/tslint.json
+++ b/packages/apollo-datasource-axios/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tslint.base.json"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -998,6 +998,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/graphql@^14.2.0":
+  version "14.2.0"
+  resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-14.2.0.tgz#74e1da5f2a4a744ac6eb3ed57b48242ea9367202"
+  integrity sha512-lELg5m6eBOmATWyCZl8qULEOvnPIUG6B443yXKj930glXIgwQirIBPp5rthP2amJW0YSzUg2s5sfgba4mRRCNw==
+
 "@types/http-cache-semantics@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz#9140779736aa2655635ee756e2467d787cfe8a2a"

--- a/yarn.lock
+++ b/yarn.lock
@@ -998,6 +998,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/http-cache-semantics@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz#9140779736aa2655635ee756e2467d787cfe8a2a"
+  integrity sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A==
+
 "@types/istanbul-lib-coverage@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.0.tgz#2cc2ca41051498382b43157c8227fea60363f94a"
@@ -1204,6 +1209,34 @@ anymatch@^2.0.0:
   dependencies:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
+
+apollo-datasource@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/apollo-datasource/-/apollo-datasource-0.3.1.tgz#4b7ec4c2dd7d08eb7edc865b95fd46b83a4679fd"
+  integrity sha512-qdEUeonc9pPZvYwXK36h2NZoT7Pddmy0HYOzdV0ON5pcG1YtNmUyyYi83Q60V5wTWjuaCjyJ9hOY6wr0BMvQuA==
+  dependencies:
+    apollo-server-caching "0.3.1"
+    apollo-server-env "2.2.0"
+
+apollo-server-caching@0.3.1, apollo-server-caching@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/apollo-server-caching/-/apollo-server-caching-0.3.1.tgz#63fcb2aaa176e1e101b36a8450e6b4c593d2767a"
+  integrity sha512-mfxzikYXbB/OoEms77AGYwRh7FF3Oim5v5XWAL+VL49FrkbZt5lopVa4bABi7Mz8Nt3Htl9EBJN8765s/yh8IA==
+  dependencies:
+    lru-cache "^5.0.0"
+
+apollo-server-env@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/apollo-server-env/-/apollo-server-env-2.2.0.tgz#5eec5dbf46581f663fd6692b2e05c7e8ae6d6034"
+  integrity sha512-wjJiI5nQWPBpNmpiLP389Ezpstp71szS6DHAeTgYLb/ulCw3CTuuA+0/E1bsThVWiQaDeHZE0sE3yI8q2zrYiA==
+  dependencies:
+    node-fetch "^2.1.2"
+    util.promisify "^1.0.0"
+
+apollo-server-errors@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/apollo-server-errors/-/apollo-server-errors-2.2.1.tgz#f68a3f845929768057da7e1c6d30517db5872205"
+  integrity sha512-wY/YE3iJVMYC+WYIf8QODBjIP4jhI+oc7kiYo9mrz7LdYPKAgxr/he+NteGcqn/0Ea9K5/ZFTGJDbEstSMeP8g==
 
 append-transform@^1.0.0:
   version "1.0.0"
@@ -3073,6 +3106,13 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
 
+graphql@^14.2.1:
+  version "14.2.1"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.2.1.tgz#779529bf9a01e7207b977a54c20670b48ca6e95c"
+  integrity sha512-2PL1UbvKeSjy/lUeJqHk+eR9CvuErXoCNwJI4jm3oNFEeY+9ELqHNKO1ZuSxAkasPkpWbmT/iMRMFxd3cEL3tQ==
+  dependencies:
+    iterall "^1.2.2"
+
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
@@ -3178,6 +3218,11 @@ http-cache-semantics@^3.8.1:
   version "3.8.1"
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz#39b0e16add9b605bf0a9ef3d9daaf4843b4cacd2"
   integrity sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==
+
+http-cache-semantics@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz#495704773277eeef6e43f9ab2c2c7d259dda25c5"
+  integrity sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew==
 
 http-proxy-agent@^2.1.0:
   version "2.1.0"
@@ -3675,6 +3720,11 @@ istanbul-reports@^2.1.1:
   integrity sha512-FzNahnidyEPBCI0HcufJoSEoKykesRlFcSzQqjH9x0+LC8tnnE/p/90PBLu8iZTxr8yYZNyTtiAujUqyN+CIxw==
   dependencies:
     handlebars "^4.1.0"
+
+iterall@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.2.2.tgz#92d70deb8028e0c39ff3164fdbf4d8b088130cd7"
+  integrity sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA==
 
 jest-changed-files@^24.5.0:
   version "24.5.0"
@@ -4409,7 +4459,7 @@ lru-cache@^4.1.2, lru-cache@^4.1.3:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
-lru-cache@^5.1.1:
+lru-cache@^5.0.0, lru-cache@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
@@ -4775,7 +4825,7 @@ node-fetch-npm@^2.0.2:
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
 
-node-fetch@^2.3.0:
+node-fetch@^2.1.2, node-fetch@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.3.0.tgz#1a1d940bbfb916a1d3e0219f037e89e71f8c5fa5"
   integrity sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==


### PR DESCRIPTION
A rest datasource that uses axios under the hood. This allows adding generic interceptors, adapters etc.
Integrates with cache and cache policies. Supports Interceptors.
```typescript
import { AxiosDataSource } from '@ovotech/apollo-datasource-axios';

interface User {
  name: string;
}

export class MyDataSource extends AxiosDataSource {
  users(id: string) {
    return this.get<User>(`/users/${id}`);
  }
}

const dataSource = new MyDataSource({ baseURL: ..., });
```