### PR TITLE
Make winstong logger more testable

### DIFF
--- a/packages/winston-logger/package.json
+++ b/packages/winston-logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ovotech/winston-logger",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "main": "dist/index.js",
   "source": "src/index.ts",
   "types": "dist/index.d.ts",
@@ -10,8 +10,10 @@
   "devDependencies": {
     "@types/jest": "^24.0.11",
     "@types/node": "^11.11.4",
+    "@types/stream-mock": "^1.2.0",
     "jest": "^24.5.0",
     "prettier": "^1.16.4",
+    "stream-mock": "^1.2.0",
     "ts-jest": "^24.0.0",
     "tslint": "^5.14.0",
     "tslint-config-prettier": "^1.18.0",

--- a/packages/winston-logger/src/index.ts
+++ b/packages/winston-logger/src/index.ts
@@ -1,4 +1,4 @@
-import * as winston from 'winston';
+import { Logger as WinstonLogger } from 'winston';
 
 export interface LoggerMeta {
   /**
@@ -33,7 +33,7 @@ export type LoggerSanitizer = (staticMeta: LoggerMeta) => LoggerMeta;
 
 export class Logger {
   constructor(
-    private logger: winston.Logger,
+    private logger: Pick<WinstonLogger, 'log'>,
     readonly staticMeta: LoggerMeta = {},
     readonly sanitizers: LoggerSanitizer[] = [],
   ) {}

--- a/packages/winston-logger/test/index.spec.ts
+++ b/packages/winston-logger/test/index.spec.ts
@@ -1,4 +1,10 @@
-import { Logger, LoggerSanitizer } from '../src';
+import { Logger, LoggerMeta, LoggerSanitizer } from '../src';
+
+interface Test {
+  level: 'silly' | 'notice' | 'warn' | 'error' | 'info';
+  message: string;
+  meta: LoggerMeta;
+}
 
 describe('Winston Logger', () => {
   it.each`
@@ -8,13 +14,12 @@ describe('Winston Logger', () => {
     ${'warn'}   | ${'test-warn'}   | ${{ warn: 'test' }}
     ${'error'}  | ${'error'}       | ${{ error: new Error('err') }}
     ${'info'}   | ${'test-info'}   | ${{ info: 'test' }}
-  `('Test logger for $level', ({ level, message, meta }) => {
-    const winstonLogger: any = { log: jest.fn() };
+  `('Test logger for $level', ({ level, message, meta }: Test) => {
+    const winstonLogger = { log: jest.fn() };
 
     const logger = new Logger(winstonLogger, { test1: 'test2' });
     const logger2 = logger.withStaticMeta({ test3: 'test4' });
 
-    // @ts-ignore
     logger[level](message, meta);
     logger2.log(level, message, { test5: 'test6', ...meta });
 
@@ -40,7 +45,7 @@ describe('Winston Logger', () => {
       { test1: 'test2', uri: '/test' },
     ],
   ])('Test sanitize', (init, meta, expected) => {
-    const winstonLogger: any = { log: jest.fn() };
+    const winstonLogger = { log: jest.fn() };
     const sanitizer1: LoggerSanitizer = data => {
       const { error, ...rest } = data;
       return rest;
@@ -61,7 +66,7 @@ describe('Winston Logger', () => {
   });
 
   it('Test withSanitizers', () => {
-    const winstonLogger: any = { log: jest.fn() };
+    const winstonLogger = { log: jest.fn() };
     const sanitizer1: LoggerSanitizer = data => {
       const { error, ...rest } = data;
       return rest;

--- a/packages/winston-logger/test/integration.spec.ts
+++ b/packages/winston-logger/test/integration.spec.ts
@@ -1,0 +1,21 @@
+import { WritableMock } from 'stream-mock';
+import { createLogger, transports } from 'winston';
+import { Logger } from '../src';
+
+describe('Integration test', () => {
+  it('Test with real stream', async () => {
+    const stream = new WritableMock({ objectMode: true });
+    const transport = new transports.Stream({ stream });
+    const winstonLogger = createLogger({ exitOnError: false, transports: [transport] });
+
+    const logger = new Logger(winstonLogger, { test1: 'test1' });
+
+    logger.error('send test', { test2: 'test2' });
+    logger.info('other test', { test3: 'test3' });
+
+    expect(stream.data).toEqual([
+      expect.objectContaining({ message: 'send test', metadata: { test2: 'test2', test1: 'test1' }, level: 'error' }),
+      expect.objectContaining({ message: 'other test', metadata: { test3: 'test3', test1: 'test1' }, level: 'info' }),
+    ]);
+  });
+});


### PR DESCRIPTION
Instead of requiring the winston logger instance to be `winston.Logger`, we ask that it only has the "log" function of `winston.Logger` since that's the only interface we are actually using.

This allows us to pass { log: jest.fn() } directly to the logger, without specifying `any` type. That way we can keep the types all the way through, even in tests.
And alternatively we could switch a logging provider that mimics `winston.Logger`'s interface (to something like "null logger" for example.

so now instead of
```typescript
const winstonLogger: any = { log: jest.fn() };
const logger = new Logger(winstonLogger, { test1: 'test2' });
```
we can just do
```typescript
const winstonLogger = { log: jest.fn() };
const logger = new Logger(winstonLogger, { test1: 'test2' });
```