### PR TITLE
Add influx-metrics-tracker package

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ BIT Team tools for working with Kafka, Avro and other misc stuff. They are split
 | [@ovotech/winston-logger](packages/winston-logger/README.md)                   | Used in prod | Wrap winston logger to hide graylog semantics and implement safe static meta contexts with PII sanitisers                                                                 |
 | [@ovotech/apollo-datasource-axios](packages/apollo-datasource-axios/README.md) | Used in prod | A rest datasource that uses axios under the hood. This allows adding generic interceptors, adapters etc. Integrates with cache and cache policies. Supports Interceptors. |
 | [@ovotech/bigquery-pg-sink](packages/bigquery-pg-sink/README.md)               | Used in prod | Stream the results of query made by [nodejs-bigquery](https://github.com/googleapis/nodejs-bigquery) into a [postgres database](https://www.postgresql.org/).             |
+| [@ovotech/influx-metrics-tracker](packages/influx-metrics-tracker/README.md)   | Used in prod | Track metrics and store them in an Influx database, with secondary [logging](packages/winston-logger/README.md) if Influx is unavailable.                                 |
 
 ## Running the tests
 

--- a/packages/influx-metrics-tracker/.npmignore
+++ b/packages/influx-metrics-tracker/.npmignore
@@ -1,0 +1,4 @@
+.*
+test/
+tsconfig.json
+tslint.json

--- a/packages/influx-metrics-tracker/LICENSE
+++ b/packages/influx-metrics-tracker/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2019 OVO Energy
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/influx-metrics-tracker/README.md
+++ b/packages/influx-metrics-tracker/README.md
@@ -37,7 +37,7 @@ const influx = new InfluxDB(influxConfig);
 
 // Create the tracker
 const metricsMeta = {
-  env: process.env.NODE_ENV,
+  extraTagName: 'some-value',
 };
 const tracker = new PerformanceMetricsTracker(influx, logger, metricsMeta);
 

--- a/packages/influx-metrics-tracker/README.md
+++ b/packages/influx-metrics-tracker/README.md
@@ -30,7 +30,7 @@ class PerformanceMetricsTracker extends MetricsTracker {
 // Create Logger and Influx instances
 const winstonLogger = winston.createLogger(...);
 const logger = new Logger(winstonLogger, { traceToken: req.headers['X-Trace-Token'] });
-const config: ISingleHostConfig = {
+const influxConfig: ISingleHostConfig = {
   host: 'my-influx-host',
 };
 const influx = new InfluxDB(influxConfig);

--- a/packages/influx-metrics-tracker/README.md
+++ b/packages/influx-metrics-tracker/README.md
@@ -1,0 +1,76 @@
+# Influx Metrics Tracker
+
+Track metrics and store them in an Influx database, with secondary logging if Influx is unavailable or invalid input is provided.
+
+## Using
+
+```bash
+yarn add @ovotech/influx-metrics-tracker
+```
+
+```typescript
+import { MetricsTracker } from '@ovotech/influx-metrics-tracker';
+import { Logger } from '@ovotech/winston-logger';
+import { InfluxDB, ISingleHostConfig } from 'influx';
+import * as winston from 'winston';
+
+// Define a specific tracker
+class PerformanceMetricsTracker extends MetricsTracker {
+  private static queryTimeMeasurementName = 'query-time';
+
+  async trackQueryTime(timeMs: number, queryName: string) {
+    await this.trackPoint(
+      PerformanceMetricsTracker.queryTimeMeasurementName,
+      { queryName },
+      { timeMs: Math.round(timeMs) },
+    );
+  }
+}
+
+// Create Logger and Influx instances
+const winstonLogger = winston.createLogger(...);
+const logger = new Logger(winstonLogger, { traceToken: req.headers['X-Trace-Token'] });
+const config: ISingleHostConfig = {
+  host: 'my-influx-host',
+};
+const influx = new InfluxDB(influxConfig);
+
+// Create the tracker
+const metricsMeta = {
+  env: process.env.NODE_ENV,
+};
+const tracker = new PerformanceMetricsTracker(influx, logger, metricsMeta);
+
+// Track a point
+await tracker.trackQueryTime(12.34, 'myFirstQuery')
+```
+
+## Running the tests
+
+Then you can run the tests with:
+
+```bash
+yarn test
+```
+
+### Coding style (linting, etc) tests
+
+Style is maintained with prettier and tslint
+
+```
+yarn lint
+```
+
+## Deployment
+
+Deployment is preferment by lerna automatically on merge / push to master, but you'll need to bump the package version numbers yourself. Only updated packages with newer versions will be pushed to the npm registry.
+
+## Contributing
+
+Have a bug? File an issue with a simple example that reproduces this so we can take a look & confirm.
+
+Want to make a change? Submit a PR, explain why it's useful, and make sure you've updated the docs (this file) and the tests (see [test folder](test)).
+
+## License
+
+This project is licensed under Apache 2 - see the [LICENSE](LICENSE) file for details

--- a/packages/influx-metrics-tracker/package.json
+++ b/packages/influx-metrics-tracker/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@ovotech/influx-metrics-tracker",
+  "description": "Track metrics and store them in an Influx database, with secondary logging if Influx is unavailable",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "source": "src/index.ts",
+  "types": "dist/index.d.ts",
+  "author": "Hayden Field <hayden.field@ovoenergy.com>",
+  "license": "Apache-2.0",
+  "scripts": {
+    "test": "jest --runInBand",
+    "lint-prettier": "prettier --list-different {src,test}/**/*.ts",
+    "lint-tslint": "tslint --config tslint.json '{src,test}/**/*.ts'",
+    "lint": "yarn lint-prettier && yarn lint-tslint",
+    "build": "tsc --outDir dist --declaration"
+  },
+  "peerDependencies": {
+    "@ovotech/winston-logger": "^1.2.5",
+    "influx": "^5.1.0"
+  },
+  "devDependencies": {
+    "@types/jest": "^24.0.13",
+    "@ovotech/winston-logger": "^1.2.5",
+    "influx": "^5.1.0",
+    "jest": "^24.8.0",
+    "prettier": "^1.17.1",
+    "ts-jest": "^24.0.2",
+    "tslint": "^5.17.0",
+    "tslint-config-prettier": "^1.18.0",
+    "typescript": "^3.5.1"
+  },
+  "jest": {
+    "preset": "../../jest-preset.json"
+  }
+}

--- a/packages/influx-metrics-tracker/package.json
+++ b/packages/influx-metrics-tracker/package.json
@@ -20,6 +20,8 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.13",
+    "@ovotech/winston-logger": "^1.2.5",
+    "influx": "^5.1.0",
     "jest": "^24.8.0",
     "prettier": "^1.17.1",
     "ts-jest": "^24.0.2",

--- a/packages/influx-metrics-tracker/package.json
+++ b/packages/influx-metrics-tracker/package.json
@@ -20,8 +20,6 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.13",
-    "@ovotech/winston-logger": "^1.2.5",
-    "influx": "^5.1.0",
     "jest": "^24.8.0",
     "prettier": "^1.17.1",
     "ts-jest": "^24.0.2",

--- a/packages/influx-metrics-tracker/src/index.ts
+++ b/packages/influx-metrics-tracker/src/index.ts
@@ -1,12 +1,14 @@
 import { Logger } from '@ovotech/winston-logger';
 import { InfluxDB } from 'influx';
 
-interface MetricsMeta {
-  [key: string]: any;
-}
-
 export abstract class MetricsTracker {
-  constructor(protected influx: InfluxDB, protected logger: Logger, protected staticMeta?: MetricsMeta) {}
+  constructor(
+    protected influx: InfluxDB,
+    protected logger: Logger,
+    protected staticMeta?: {
+      [key: string]: any;
+    },
+  ) {}
 
   protected async trackPoint(
     measurementName: string,

--- a/packages/influx-metrics-tracker/src/index.ts
+++ b/packages/influx-metrics-tracker/src/index.ts
@@ -1,0 +1,59 @@
+import { Logger } from '@ovotech/winston-logger';
+import { InfluxDB } from 'influx';
+
+interface MetricsMeta {}
+
+export abstract class MetricsTracker {
+  constructor(protected influx: InfluxDB, protected logger: Logger, protected staticMeta?: MetricsMeta) {}
+
+  protected async trackPoint(
+    measurementName: string,
+    tags: { [name: string]: string },
+    fields: { [name: string]: any },
+  ) {
+    const validTags = this.getValidTags(tags);
+    this.logInvalidTags(measurementName, tags);
+
+    try {
+      await this.influx.writePoints([
+        {
+          measurement: measurementName,
+          tags: {
+            ...this.staticMeta,
+            ...validTags,
+          },
+          fields,
+        },
+      ]);
+    } catch (err) {
+      this.logger.error('Error tracking Influx metric', {
+        metric: measurementName,
+        tags: JSON.stringify(validTags),
+        fields: JSON.stringify(fields),
+      });
+    }
+  }
+
+  private getInvalidTagNames(tags: { [name: string]: string }) {
+    return Object.entries(tags)
+      .filter(([_, value]) => value.length === 0)
+      .reduce((names: string[], [key, _]) => names.concat([key]), []);
+  }
+
+  private getValidTags(tags: { [name: string]: string }) {
+    return Object.entries(tags)
+      .filter(([_, value]) => value.length > 0)
+      .reduce((obj, [key, value]) => ({ ...obj, [key]: value }), {});
+  }
+
+  private logInvalidTags(measurementName: string, tags: { [name: string]: string }) {
+    const invalidTagNames = this.getInvalidTagNames(tags);
+
+    if (invalidTagNames.length) {
+      this.logger.warn('Attempted to track tags with no value', {
+        metric: measurementName,
+        tagNames: invalidTagNames.sort().join(', '),
+      });
+    }
+  }
+}

--- a/packages/influx-metrics-tracker/src/index.ts
+++ b/packages/influx-metrics-tracker/src/index.ts
@@ -1,7 +1,9 @@
 import { Logger } from '@ovotech/winston-logger';
 import { InfluxDB } from 'influx';
 
-interface MetricsMeta {}
+interface MetricsMeta {
+  [key: string]: any;
+}
 
 export abstract class MetricsTracker {
   constructor(protected influx: InfluxDB, protected logger: Logger, protected staticMeta?: MetricsMeta) {}

--- a/packages/influx-metrics-tracker/test/index.spec.ts
+++ b/packages/influx-metrics-tracker/test/index.spec.ts
@@ -1,0 +1,93 @@
+import { MetricsTracker } from '../src';
+
+const testMeasurementName = 'test-metrics';
+
+export class TestTracker extends MetricsTracker {
+  private static testMeasurementName = testMeasurementName;
+
+  async trackSomething(tags: { [name: string]: string }, fields: { [name: string]: any }) {
+    await this.trackPoint(TestTracker.testMeasurementName, tags, fields);
+  }
+}
+
+describe('Base metrics class', () => {
+  const metricsMeta = {
+    workspace: 'test-test',
+  };
+  let mockInflux: any;
+  let mockLogger: any;
+  let tracker: TestTracker;
+
+  beforeEach(() => {
+    mockInflux = { writePoints: jest.fn().mockResolvedValue(undefined) };
+    mockLogger = { error: jest.fn(), warn: jest.fn() };
+    tracker = new TestTracker(mockInflux, mockLogger, metricsMeta);
+  });
+
+  it('Should track valid tags', async () => {
+    const tags = { value: 'A string' };
+
+    await tracker.trackSomething(tags, {});
+
+    expect(mockInflux.writePoints).toHaveBeenLastCalledWith([
+      {
+        measurement: testMeasurementName,
+        tags: {
+          ...metricsMeta,
+          ...tags,
+        },
+        fields: {},
+      },
+    ]);
+  });
+
+  it('Should track valid metrics', async () => {
+    const metrics = { string: 'A string', integer: 3, float: 1.23, boolean: true };
+
+    await tracker.trackSomething({}, metrics);
+
+    expect(mockInflux.writePoints).toHaveBeenLastCalledWith([
+      {
+        measurement: testMeasurementName,
+        tags: {
+          ...metricsMeta,
+        },
+        fields: { ...metrics },
+      },
+    ]);
+  });
+
+  it('Should log rather than track that have empty values', async () => {
+    const validTags = { validTag: 'A string' };
+    const invalidTags = { invalidTag: '', anotherInvalidTag: '' };
+
+    await tracker.trackSomething({ ...validTags, ...invalidTags }, {});
+
+    expect(mockInflux.writePoints).toHaveBeenLastCalledWith([
+      {
+        measurement: testMeasurementName,
+        tags: {
+          ...metricsMeta,
+          ...validTags,
+        },
+        fields: {},
+      },
+    ]);
+    expect(mockLogger.warn).toHaveBeenLastCalledWith('Attempted to track tags with no value', {
+      metric: testMeasurementName,
+      tagNames: 'anotherInvalidTag, invalidTag',
+    });
+  });
+
+  it('Should handle influx errors', async () => {
+    mockInflux.writePoints.mockRejectedValueOnce('Influx raised an error');
+
+    await tracker.trackSomething({ testTag: 'Bob' }, { timeMs: 0 });
+
+    expect(mockLogger.error).toHaveBeenLastCalledWith('Error tracking Influx metric', {
+      metric: testMeasurementName,
+      tags: '{"testTag":"Bob"}',
+      fields: '{"timeMs":0}',
+    });
+  });
+});

--- a/packages/influx-metrics-tracker/test/index.spec.ts
+++ b/packages/influx-metrics-tracker/test/index.spec.ts
@@ -12,7 +12,7 @@ export class TestTracker extends MetricsTracker {
 
 describe('Base metrics class', () => {
   const metricsMeta = {
-    workspace: 'test-test',
+    extraTagName: 'some-value',
   };
   let mockInflux: any;
   let mockLogger: any;

--- a/packages/influx-metrics-tracker/tsconfig.json
+++ b/packages/influx-metrics-tracker/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/influx-metrics-tracker/tslint.json
+++ b/packages/influx-metrics-tracker/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tslint.base.json"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3370,6 +3370,11 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
+influx@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/influx/-/influx-5.1.0.tgz#4330782c2931fa9a6941bb471ff3c904f1c3a1cd"
+  integrity sha512-ZVCnzdL2isEk34j+QyFUVT/o3PZJhfbLHm0bV6N4K+2UEUTuba0xDgwYpXgrRiis4DIiBJutw0nPoQ2zgZB1ZA==
+
 inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"


### PR DESCRIPTION
This will track metrics and store them in an Influx database.
There is secondary logging if Influx is unavailable or invalid input is provided.

A base class is provided, allowing custom trackers to be built on top.