### PR TITLE
Add specific metrics trackers

### DIFF
--- a/packages/influx-metrics-tracker/README.md
+++ b/packages/influx-metrics-tracker/README.md
@@ -42,6 +42,12 @@ const tracker = new PerformanceMetricsTracker(influx, logger, metricsMeta);
 await tracker.trackQueryTime(12.34, 'myFirstQuery')
 ```
 
+As well as a base class that allows you to define custom trackers, there are pre-defined trackers for common operations.
+These allow services to use a common interface and not re-implement the same functionality.
+
+- `KafkaMetricsTracker` - track actions around the lifecycle of Kafka events
+- `ResponseMetricsTracker` - track information about responses from an API
+
 ## Running the tests
 
 Then you can run the tests with:

--- a/packages/influx-metrics-tracker/README.md
+++ b/packages/influx-metrics-tracker/README.md
@@ -9,7 +9,7 @@ yarn add @ovotech/influx-metrics-tracker
 ```
 
 ```typescript
-import { MetricsTracker } from '@ovotech/influx-metrics-tracker';
+import { createInfluxConnection, MetricsTracker } from '@ovotech/influx-metrics-tracker';
 import { Logger } from '@ovotech/winston-logger';
 import { InfluxDB, ISingleHostConfig } from 'influx';
 import * as winston from 'winston';
@@ -30,10 +30,7 @@ class PerformanceMetricsTracker extends MetricsTracker {
 // Create Logger and Influx instances
 const winstonLogger = winston.createLogger(...);
 const logger = new Logger(winstonLogger, { traceToken: req.headers['X-Trace-Token'] });
-const influxConfig: ISingleHostConfig = {
-  host: 'my-influx-host',
-};
-const influx = new InfluxDB(influxConfig);
+const influx = createInfluxConnection(process.env);
 
 // Create the tracker
 const metricsMeta = {

--- a/packages/influx-metrics-tracker/README.md
+++ b/packages/influx-metrics-tracker/README.md
@@ -45,6 +45,7 @@ await tracker.trackQueryTime(12.34, 'myFirstQuery')
 As well as a base class that allows you to define custom trackers, there are pre-defined trackers for common operations.
 These allow services to use a common interface and not re-implement the same functionality.
 
+- `ExternalRequestMetricsTracker` - track information about calling other services
 - `KafkaMetricsTracker` - track actions around the lifecycle of Kafka events
 - `ResponseMetricsTracker` - track information about responses from an API
 

--- a/packages/influx-metrics-tracker/package.json
+++ b/packages/influx-metrics-tracker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ovotech/influx-metrics-tracker",
   "description": "Track metrics and store them in an Influx database, with secondary logging if Influx is unavailable",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "dist/index.js",
   "source": "src/index.ts",
   "types": "dist/index.d.ts",

--- a/packages/influx-metrics-tracker/src/base.ts
+++ b/packages/influx-metrics-tracker/src/base.ts
@@ -1,0 +1,63 @@
+import { Logger } from '@ovotech/winston-logger';
+import { InfluxDB } from 'influx';
+
+export abstract class MetricsTracker {
+  constructor(
+    protected influx: InfluxDB,
+    protected logger: Logger,
+    protected staticMeta?: {
+      [key: string]: any;
+    },
+  ) {}
+
+  protected async trackPoint(
+    measurementName: string,
+    tags: { [name: string]: string },
+    fields: { [name: string]: any },
+  ) {
+    const validTags = this.getValidTags(tags);
+    this.logInvalidTags(measurementName, tags);
+
+    try {
+      await this.influx.writePoints([
+        {
+          measurement: measurementName,
+          tags: {
+            ...this.staticMeta,
+            ...validTags,
+          },
+          fields,
+        },
+      ]);
+    } catch (err) {
+      this.logger.error('Error tracking Influx metric', {
+        metric: measurementName,
+        tags: JSON.stringify(validTags),
+        fields: JSON.stringify(fields),
+      });
+    }
+  }
+
+  private getInvalidTagNames(tags: { [name: string]: string }) {
+    return Object.entries(tags)
+      .filter(([_, value]) => value.length === 0)
+      .reduce((names: string[], [key, _]) => names.concat([key]), []);
+  }
+
+  private getValidTags(tags: { [name: string]: string }) {
+    return Object.entries(tags)
+      .filter(([_, value]) => value.length > 0)
+      .reduce((obj, [key, value]) => ({ ...obj, [key]: value }), {});
+  }
+
+  private logInvalidTags(measurementName: string, tags: { [name: string]: string }) {
+    const invalidTagNames = this.getInvalidTagNames(tags);
+
+    if (invalidTagNames.length) {
+      this.logger.warn('Attempted to track tags with no value', {
+        metric: measurementName,
+        tagNames: invalidTagNames.sort().join(', '),
+      });
+    }
+  }
+}

--- a/packages/influx-metrics-tracker/src/external-request.ts
+++ b/packages/influx-metrics-tracker/src/external-request.ts
@@ -1,0 +1,13 @@
+import { MetricsTracker } from '@ovotech/influx-metrics-tracker';
+
+export class ExternalRequestMetricsTracker extends MetricsTracker {
+  private static externalRequestTimeMeasurementName = 'external-request-time';
+
+  async trackRequestTime(externalServiceName: string, requestName: string, timeMs: number, statusCode?: number) {
+    await this.trackPoint(
+      ExternalRequestMetricsTracker.externalRequestTimeMeasurementName,
+      { requestName, externalServiceName, status: statusCode ? statusCode.toString() : '' },
+      { timeMs: Math.round(timeMs), count: 1 },
+    );
+  }
+}

--- a/packages/influx-metrics-tracker/src/external-request.ts
+++ b/packages/influx-metrics-tracker/src/external-request.ts
@@ -1,4 +1,4 @@
-import { MetricsTracker } from '@ovotech/influx-metrics-tracker';
+import { MetricsTracker } from './base';
 
 export class ExternalRequestMetricsTracker extends MetricsTracker {
   private static externalRequestTimeMeasurementName = 'external-request-time';

--- a/packages/influx-metrics-tracker/src/index.ts
+++ b/packages/influx-metrics-tracker/src/index.ts
@@ -1,6 +1,8 @@
 import { InfluxDB, ISingleHostConfig } from 'influx';
 
 export { MetricsTracker } from './base';
+export { KafkaMetricsTracker } from './kafka';
+export { ResponseMetricsTracker } from './response';
 
 export interface InfluxConfig extends NodeJS.ProcessEnv {
   INFLUXDB_HOST?: string;

--- a/packages/influx-metrics-tracker/src/index.ts
+++ b/packages/influx-metrics-tracker/src/index.ts
@@ -1,6 +1,7 @@
 import { InfluxDB, ISingleHostConfig } from 'influx';
 
 export { MetricsTracker } from './base';
+export { ExternalRequestMetricsTracker } from './external-request';
 export { KafkaMetricsTracker } from './kafka';
 export { ResponseMetricsTracker } from './response';
 

--- a/packages/influx-metrics-tracker/src/index.ts
+++ b/packages/influx-metrics-tracker/src/index.ts
@@ -1,63 +1,29 @@
-import { Logger } from '@ovotech/winston-logger';
-import { InfluxDB } from 'influx';
+import { InfluxDB, ISingleHostConfig } from 'influx';
 
-export abstract class MetricsTracker {
-  constructor(
-    protected influx: InfluxDB,
-    protected logger: Logger,
-    protected staticMeta?: {
-      [key: string]: any;
-    },
-  ) {}
+export { MetricsTracker } from './base';
 
-  protected async trackPoint(
-    measurementName: string,
-    tags: { [name: string]: string },
-    fields: { [name: string]: any },
-  ) {
-    const validTags = this.getValidTags(tags);
-    this.logInvalidTags(measurementName, tags);
-
-    try {
-      await this.influx.writePoints([
-        {
-          measurement: measurementName,
-          tags: {
-            ...this.staticMeta,
-            ...validTags,
-          },
-          fields,
-        },
-      ]);
-    } catch (err) {
-      this.logger.error('Error tracking Influx metric', {
-        metric: measurementName,
-        tags: JSON.stringify(validTags),
-        fields: JSON.stringify(fields),
-      });
-    }
-  }
-
-  private getInvalidTagNames(tags: { [name: string]: string }) {
-    return Object.entries(tags)
-      .filter(([_, value]) => value.length === 0)
-      .reduce((names: string[], [key, _]) => names.concat([key]), []);
-  }
-
-  private getValidTags(tags: { [name: string]: string }) {
-    return Object.entries(tags)
-      .filter(([_, value]) => value.length > 0)
-      .reduce((obj, [key, value]) => ({ ...obj, [key]: value }), {});
-  }
-
-  private logInvalidTags(measurementName: string, tags: { [name: string]: string }) {
-    const invalidTagNames = this.getInvalidTagNames(tags);
-
-    if (invalidTagNames.length) {
-      this.logger.warn('Attempted to track tags with no value', {
-        metric: measurementName,
-        tagNames: invalidTagNames.sort().join(', '),
-      });
-    }
-  }
+export interface InfluxConfig extends NodeJS.ProcessEnv {
+  INFLUXDB_HOST?: string;
+  INFLUXDB_DATABASE?: string;
+  INFLUXDB_PORT?: string;
+  INFLUXDB_USER?: string;
+  INFLUXDB_PASSWORD?: string;
 }
+
+export const createInfluxConnection = ({
+  INFLUXDB_HOST = '',
+  INFLUXDB_DATABASE = 'default-db',
+  INFLUXDB_PORT = '15661',
+  INFLUXDB_USER = '',
+  INFLUXDB_PASSWORD = '',
+}: InfluxConfig): InfluxDB => {
+  const config: ISingleHostConfig = {
+    host: INFLUXDB_HOST,
+    database: INFLUXDB_DATABASE,
+    port: parseInt(INFLUXDB_PORT, 10),
+    username: INFLUXDB_USER,
+    password: INFLUXDB_PASSWORD,
+    protocol: 'https',
+  };
+  return new InfluxDB(config);
+};

--- a/packages/influx-metrics-tracker/src/kafka.ts
+++ b/packages/influx-metrics-tracker/src/kafka.ts
@@ -8,7 +8,7 @@ export class KafkaMetricsTracker extends MetricsTracker {
     await this.trackPoint(KafkaMetricsTracker.eventReceivedMeasurementName, { eventName }, { count: 1, ageMs });
   }
 
-  async trackEventProcessed(eventName: string, processingState: KafkaMetricsTracker.ProcessingState) {
+  async trackEventProcessed(eventName: string, processingState: ProcessingState) {
     await this.trackPoint(
       KafkaMetricsTracker.eventProcessedMeasurementName,
       { eventName, processingState },
@@ -17,10 +17,7 @@ export class KafkaMetricsTracker extends MetricsTracker {
   }
 }
 
-// tslint:disable-next-line:no-namespace
-export namespace KafkaMetricsTracker {
-  export enum ProcessingState {
-    Error = 'error',
-    Success = 'success',
-  }
+export enum ProcessingState {
+  Error = 'error',
+  Success = 'success',
 }

--- a/packages/influx-metrics-tracker/src/kafka.ts
+++ b/packages/influx-metrics-tracker/src/kafka.ts
@@ -5,7 +5,11 @@ export class KafkaMetricsTracker extends MetricsTracker {
   private static eventReceivedMeasurementName = 'kafka-event-received';
 
   async trackEventReceived(eventName: string, ageMs: number) {
-    await this.trackPoint(KafkaMetricsTracker.eventReceivedMeasurementName, { eventName }, { count: 1, ageMs });
+    await this.trackPoint(
+      KafkaMetricsTracker.eventReceivedMeasurementName,
+      { eventName },
+      { count: 1, ageMs: Math.round(ageMs) },
+    );
   }
 
   async trackEventProcessed(eventName: string, processingState: ProcessingState) {

--- a/packages/influx-metrics-tracker/src/kafka.ts
+++ b/packages/influx-metrics-tracker/src/kafka.ts
@@ -1,0 +1,26 @@
+import { MetricsTracker } from './base';
+
+export class KafkaMetricsTracker extends MetricsTracker {
+  private static eventProcessedMeasurementName = 'kafka-event-processed';
+  private static eventReceivedMeasurementName = 'kafka-event-received';
+
+  async trackEventReceived(eventName: string, ageMs: number) {
+    await this.trackPoint(KafkaMetricsTracker.eventReceivedMeasurementName, { eventName }, { count: 1, ageMs });
+  }
+
+  async trackEventProcessed(eventName: string, processingState: KafkaMetricsTracker.ProcessingState) {
+    await this.trackPoint(
+      KafkaMetricsTracker.eventProcessedMeasurementName,
+      { eventName, processingState },
+      { count: 1 },
+    );
+  }
+}
+
+// tslint:disable-next-line:no-namespace
+export namespace KafkaMetricsTracker {
+  export enum ProcessingState {
+    Error = 'error',
+    Success = 'success',
+  }
+}

--- a/packages/influx-metrics-tracker/src/response.ts
+++ b/packages/influx-metrics-tracker/src/response.ts
@@ -1,0 +1,13 @@
+import { MetricsTracker } from './base';
+
+export class ResponseMetricsTracker extends MetricsTracker {
+  private static ownResponseTimeMeasurementName = 'own-response-time';
+
+  async trackOwnResponseTime(requestName: string, timeMs: number, statusCode?: number) {
+    await this.trackPoint(
+      ResponseMetricsTracker.ownResponseTimeMeasurementName,
+      { requestName, status: statusCode ? statusCode.toString() : '' },
+      { timeMs: Math.round(timeMs), count: 1 },
+    );
+  }
+}

--- a/packages/influx-metrics-tracker/test/base.spec.ts
+++ b/packages/influx-metrics-tracker/test/base.spec.ts
@@ -1,0 +1,93 @@
+import { MetricsTracker } from '../src';
+
+const testMeasurementName = 'test-metrics';
+
+export class TestTracker extends MetricsTracker {
+  private static testMeasurementName = testMeasurementName;
+
+  async trackSomething(tags: { [name: string]: string }, fields: { [name: string]: any }) {
+    await this.trackPoint(TestTracker.testMeasurementName, tags, fields);
+  }
+}
+
+describe('Base metrics class', () => {
+  const metricsMeta = {
+    extraTagName: 'some-value',
+  };
+  let mockInflux: any;
+  let mockLogger: any;
+  let tracker: TestTracker;
+
+  beforeEach(() => {
+    mockInflux = { writePoints: jest.fn().mockResolvedValue(undefined) };
+    mockLogger = { error: jest.fn(), warn: jest.fn() };
+    tracker = new TestTracker(mockInflux, mockLogger, metricsMeta);
+  });
+
+  it('Should track valid tags', async () => {
+    const tags = { value: 'A string' };
+
+    await tracker.trackSomething(tags, {});
+
+    expect(mockInflux.writePoints).toHaveBeenLastCalledWith([
+      {
+        measurement: testMeasurementName,
+        tags: {
+          ...metricsMeta,
+          ...tags,
+        },
+        fields: {},
+      },
+    ]);
+  });
+
+  it('Should track valid metrics', async () => {
+    const metrics = { string: 'A string', integer: 3, float: 1.23, boolean: true };
+
+    await tracker.trackSomething({}, metrics);
+
+    expect(mockInflux.writePoints).toHaveBeenLastCalledWith([
+      {
+        measurement: testMeasurementName,
+        tags: {
+          ...metricsMeta,
+        },
+        fields: { ...metrics },
+      },
+    ]);
+  });
+
+  it('Should log rather than track that have empty values', async () => {
+    const validTags = { validTag: 'A string' };
+    const invalidTags = { invalidTag: '', anotherInvalidTag: '' };
+
+    await tracker.trackSomething({ ...validTags, ...invalidTags }, {});
+
+    expect(mockInflux.writePoints).toHaveBeenLastCalledWith([
+      {
+        measurement: testMeasurementName,
+        tags: {
+          ...metricsMeta,
+          ...validTags,
+        },
+        fields: {},
+      },
+    ]);
+    expect(mockLogger.warn).toHaveBeenLastCalledWith('Attempted to track tags with no value', {
+      metric: testMeasurementName,
+      tagNames: 'anotherInvalidTag, invalidTag',
+    });
+  });
+
+  it('Should handle influx errors', async () => {
+    mockInflux.writePoints.mockRejectedValueOnce('Influx raised an error');
+
+    await tracker.trackSomething({ testTag: 'Bob' }, { timeMs: 0 });
+
+    expect(mockLogger.error).toHaveBeenLastCalledWith('Error tracking Influx metric', {
+      metric: testMeasurementName,
+      tags: '{"testTag":"Bob"}',
+      fields: '{"timeMs":0}',
+    });
+  });
+});

--- a/packages/influx-metrics-tracker/test/external-request.spec.ts
+++ b/packages/influx-metrics-tracker/test/external-request.spec.ts
@@ -1,0 +1,82 @@
+import { ExternalRequestMetricsTracker } from '../src/external-request';
+
+describe('Track actions relating to consuming an event from Kafka', () => {
+  let mockInflux: any;
+  let mockLogger: any;
+  let tracker: ExternalRequestMetricsTracker;
+
+  beforeEach(() => {
+    mockInflux = { writePoints: jest.fn().mockResolvedValue(undefined) };
+    mockLogger = { error: jest.fn(), warn: jest.fn() };
+    tracker = new ExternalRequestMetricsTracker(mockInflux, mockLogger);
+  });
+
+  it('Should track a request time without a status code', async () => {
+    const externalServiceName = 'test-external-service';
+    const requestName = 'test-request';
+    const timeMs = 1234;
+
+    await tracker.trackRequestTime(externalServiceName, requestName, timeMs);
+
+    expect(mockInflux.writePoints).toHaveBeenLastCalledWith([
+      {
+        measurement: 'external-request-time',
+        tags: {
+          externalServiceName,
+          requestName,
+        },
+        fields: {
+          count: 1,
+          timeMs: 1234,
+        },
+      },
+    ]);
+  });
+
+  it.each([200, 404, 500])('Should track a request time with a status code: %d', async statusCode => {
+    const externalServiceName = 'test-external-service';
+    const requestName = 'test-request';
+    const timeMs = 123;
+
+    await tracker.trackRequestTime(externalServiceName, requestName, timeMs, statusCode);
+
+    expect(mockInflux.writePoints).toHaveBeenLastCalledWith([
+      {
+        measurement: 'external-request-time',
+        tags: {
+          externalServiceName,
+          requestName,
+          status: statusCode.toString(10),
+        },
+        fields: {
+          count: 1,
+          timeMs: 123,
+        },
+      },
+    ]);
+  });
+
+  it.each([[1234.5, 1235], [123.4, 123], [10, 10]])(
+    'Should round response times to the nearest millisecond: %d',
+    async (exactTime, expectedTrackedTime) => {
+      const externalServiceName = 'test-external-service';
+      const requestName = 'test-request';
+
+      await tracker.trackRequestTime(externalServiceName, requestName, exactTime);
+
+      expect(mockInflux.writePoints).toHaveBeenLastCalledWith([
+        {
+          measurement: 'external-request-time',
+          tags: {
+            externalServiceName,
+            requestName,
+          },
+          fields: {
+            count: 1,
+            timeMs: expectedTrackedTime,
+          },
+        },
+      ]);
+    },
+  );
+});

--- a/packages/influx-metrics-tracker/test/index.spec.ts
+++ b/packages/influx-metrics-tracker/test/index.spec.ts
@@ -1,93 +1,25 @@
-import { MetricsTracker } from '../src';
+jest.mock('influx');
+import { InfluxDB } from 'influx';
+import { createInfluxConnection, InfluxConfig } from '../src/index';
 
-const testMeasurementName = 'test-metrics';
+describe('Create InfluxDB and connection', () => {
+  it('Should create a DB with partial config', () => {
+    const config: InfluxConfig = {
+      INFLUXDB_HOST: 'test-host',
+      INFLUXDB_PORT: '123',
+      INFLUXDB_USER: 'test-user',
+      INFLUXDB_PASSWORD: 'test-password',
+    };
 
-export class TestTracker extends MetricsTracker {
-  private static testMeasurementName = testMeasurementName;
+    createInfluxConnection(config);
 
-  async trackSomething(tags: { [name: string]: string }, fields: { [name: string]: any }) {
-    await this.trackPoint(TestTracker.testMeasurementName, tags, fields);
-  }
-}
-
-describe('Base metrics class', () => {
-  const metricsMeta = {
-    extraTagName: 'some-value',
-  };
-  let mockInflux: any;
-  let mockLogger: any;
-  let tracker: TestTracker;
-
-  beforeEach(() => {
-    mockInflux = { writePoints: jest.fn().mockResolvedValue(undefined) };
-    mockLogger = { error: jest.fn(), warn: jest.fn() };
-    tracker = new TestTracker(mockInflux, mockLogger, metricsMeta);
-  });
-
-  it('Should track valid tags', async () => {
-    const tags = { value: 'A string' };
-
-    await tracker.trackSomething(tags, {});
-
-    expect(mockInflux.writePoints).toHaveBeenLastCalledWith([
-      {
-        measurement: testMeasurementName,
-        tags: {
-          ...metricsMeta,
-          ...tags,
-        },
-        fields: {},
-      },
-    ]);
-  });
-
-  it('Should track valid metrics', async () => {
-    const metrics = { string: 'A string', integer: 3, float: 1.23, boolean: true };
-
-    await tracker.trackSomething({}, metrics);
-
-    expect(mockInflux.writePoints).toHaveBeenLastCalledWith([
-      {
-        measurement: testMeasurementName,
-        tags: {
-          ...metricsMeta,
-        },
-        fields: { ...metrics },
-      },
-    ]);
-  });
-
-  it('Should log rather than track that have empty values', async () => {
-    const validTags = { validTag: 'A string' };
-    const invalidTags = { invalidTag: '', anotherInvalidTag: '' };
-
-    await tracker.trackSomething({ ...validTags, ...invalidTags }, {});
-
-    expect(mockInflux.writePoints).toHaveBeenLastCalledWith([
-      {
-        measurement: testMeasurementName,
-        tags: {
-          ...metricsMeta,
-          ...validTags,
-        },
-        fields: {},
-      },
-    ]);
-    expect(mockLogger.warn).toHaveBeenLastCalledWith('Attempted to track tags with no value', {
-      metric: testMeasurementName,
-      tagNames: 'anotherInvalidTag, invalidTag',
-    });
-  });
-
-  it('Should handle influx errors', async () => {
-    mockInflux.writePoints.mockRejectedValueOnce('Influx raised an error');
-
-    await tracker.trackSomething({ testTag: 'Bob' }, { timeMs: 0 });
-
-    expect(mockLogger.error).toHaveBeenLastCalledWith('Error tracking Influx metric', {
-      metric: testMeasurementName,
-      tags: '{"testTag":"Bob"}',
-      fields: '{"timeMs":0}',
+    expect(InfluxDB).lastCalledWith({
+      database: 'default-db',
+      host: 'test-host',
+      password: 'test-password',
+      port: 123,
+      protocol: 'https',
+      username: 'test-user',
     });
   });
 });

--- a/packages/influx-metrics-tracker/test/kafka.spec.ts
+++ b/packages/influx-metrics-tracker/test/kafka.spec.ts
@@ -1,0 +1,55 @@
+import { KafkaMetricsTracker } from '../src/kafka';
+
+describe('Track actions relating to consuming an event from Kafka', () => {
+  let mockInflux: any;
+  let mockLogger: any;
+  let tracker: KafkaMetricsTracker;
+
+  beforeEach(() => {
+    mockInflux = { writePoints: jest.fn().mockResolvedValue(undefined) };
+    mockLogger = { error: jest.fn(), warn: jest.fn() };
+    tracker = new KafkaMetricsTracker(mockInflux, mockLogger);
+  });
+
+  it('Should track a single event being received', async () => {
+    const eventName = 'test-event';
+    const ageMs = 123;
+
+    await tracker.trackEventReceived(eventName, ageMs);
+
+    expect(mockInflux.writePoints).toHaveBeenLastCalledWith([
+      {
+        measurement: 'kafka-event-received',
+        tags: {
+          eventName,
+        },
+        fields: {
+          count: 1,
+          ageMs,
+        },
+      },
+    ]);
+  });
+
+  it.each([KafkaMetricsTracker.ProcessingState.Error, KafkaMetricsTracker.ProcessingState.Success])(
+    'Should track the state of a processed event: %s',
+    async processingState => {
+      const eventName = 'test-event';
+
+      await tracker.trackEventProcessed(eventName, processingState);
+
+      expect(mockInflux.writePoints).toHaveBeenLastCalledWith([
+        {
+          measurement: 'kafka-event-processed',
+          tags: {
+            eventName,
+            processingState,
+          },
+          fields: {
+            count: 1,
+          },
+        },
+      ]);
+    },
+  );
+});

--- a/packages/influx-metrics-tracker/test/kafka.spec.ts
+++ b/packages/influx-metrics-tracker/test/kafka.spec.ts
@@ -31,6 +31,28 @@ describe('Track actions relating to consuming an event from Kafka', () => {
     ]);
   });
 
+  it.each([[1234.5, 1235], [123.4, 123], [10, 10]])(
+    'Should round event ages to the nearest millisecond: %d',
+    async (exactAge, expectedTrackedAge) => {
+      const eventName = 'test-event';
+
+      await tracker.trackEventReceived(eventName, exactAge);
+
+      expect(mockInflux.writePoints).toHaveBeenLastCalledWith([
+        {
+          measurement: 'kafka-event-received',
+          tags: {
+            eventName,
+          },
+          fields: {
+            count: 1,
+            ageMs: expectedTrackedAge,
+          },
+        },
+      ]);
+    },
+  );
+
   it.each([ProcessingState.Error, ProcessingState.Success])(
     'Should track the state of a processed event: %s',
     async processingState => {

--- a/packages/influx-metrics-tracker/test/kafka.spec.ts
+++ b/packages/influx-metrics-tracker/test/kafka.spec.ts
@@ -1,4 +1,4 @@
-import { KafkaMetricsTracker } from '../src/kafka';
+import { KafkaMetricsTracker, ProcessingState } from '../src/kafka';
 
 describe('Track actions relating to consuming an event from Kafka', () => {
   let mockInflux: any;
@@ -31,7 +31,7 @@ describe('Track actions relating to consuming an event from Kafka', () => {
     ]);
   });
 
-  it.each([KafkaMetricsTracker.ProcessingState.Error, KafkaMetricsTracker.ProcessingState.Success])(
+  it.each([ProcessingState.Error, ProcessingState.Success])(
     'Should track the state of a processed event: %s',
     async processingState => {
       const eventName = 'test-event';

--- a/packages/influx-metrics-tracker/test/response.spec.ts
+++ b/packages/influx-metrics-tracker/test/response.spec.ts
@@ -1,0 +1,54 @@
+import { ResponseMetricsTracker } from '../src/response';
+
+describe('Track actions relating to responding to an API request', () => {
+  let mockInflux: any;
+  let mockLogger: any;
+  let tracker: ResponseMetricsTracker;
+
+  beforeEach(() => {
+    mockInflux = { writePoints: jest.fn().mockResolvedValue(undefined) };
+    mockLogger = { error: jest.fn(), warn: jest.fn() };
+    tracker = new ResponseMetricsTracker(mockInflux, mockLogger);
+  });
+
+  it('Should track a response time without a status code', async () => {
+    const requestName = 'test-request';
+    const timeMs = 1234;
+
+    await tracker.trackOwnResponseTime(requestName, timeMs);
+
+    expect(mockInflux.writePoints).toHaveBeenLastCalledWith([
+      {
+        measurement: 'own-response-time',
+        tags: {
+          requestName,
+        },
+        fields: {
+          count: 1,
+          timeMs: 1234,
+        },
+      },
+    ]);
+  });
+
+  it.each([200, 404, 500])('Should track a response time with a status code: %d', async statusCode => {
+    const requestName = 'test-request';
+    const timeMs = 123;
+
+    await tracker.trackOwnResponseTime(requestName, timeMs, statusCode);
+
+    expect(mockInflux.writePoints).toHaveBeenLastCalledWith([
+      {
+        measurement: 'own-response-time',
+        tags: {
+          requestName,
+          status: statusCode.toString(10),
+        },
+        fields: {
+          count: 1,
+          timeMs: 123,
+        },
+      },
+    ]);
+  });
+});

--- a/packages/influx-metrics-tracker/test/response.spec.ts
+++ b/packages/influx-metrics-tracker/test/response.spec.ts
@@ -51,4 +51,26 @@ describe('Track actions relating to responding to an API request', () => {
       },
     ]);
   });
+
+  it.each([[1234.5, 1235], [123.4, 123], [10, 10]])(
+    'Should round response times to the nearest millisecond: %d',
+    async (exactTime, expectedTrackedTime) => {
+      const requestName = 'test-request';
+
+      await tracker.trackOwnResponseTime(requestName, exactTime);
+
+      expect(mockInflux.writePoints).toHaveBeenLastCalledWith([
+        {
+          measurement: 'own-response-time',
+          tags: {
+            requestName,
+          },
+          fields: {
+            count: 1,
+            timeMs: expectedTrackedTime,
+          },
+        },
+      ]);
+    },
+  );
 });


### PR DESCRIPTION
This adds a couple of trackers that perform common actions. These allow services to use a common interface and not re-implement the same functionality.

- `ExternalRequestMetricsTracker` - track information about calling other services
- `KafkaMetricsTracker` - track actions around the lifecycle of Kafka events
- `ResponseMetricsTracker` - track information about responses from an API