### PR TITLE
Add a missing dependency

### DIFF
--- a/packages/influx-metrics-tracker/package.json
+++ b/packages/influx-metrics-tracker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ovotech/influx-metrics-tracker",
   "description": "Track metrics and store them in an Influx database, with secondary logging if Influx is unavailable",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "dist/index.js",
   "source": "src/index.ts",
   "types": "dist/index.d.ts",
@@ -14,14 +14,15 @@
     "lint": "yarn lint-prettier && yarn lint-tslint",
     "build": "tsc --outDir dist --declaration"
   },
+  "dependencies": {
+    "influx": "^5.2.0"
+  },
   "peerDependencies": {
-    "@ovotech/winston-logger": "^1.2.5",
-    "influx": "^5.1.0"
+    "@ovotech/winston-logger": "^1.2.5"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.13",
     "@ovotech/winston-logger": "^1.2.5",
-    "influx": "^5.1.0",
+    "@types/jest": "^24.0.13",
     "jest": "^24.8.0",
     "prettier": "^1.17.1",
     "ts-jest": "^24.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3370,10 +3370,10 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-influx@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/influx/-/influx-5.1.0.tgz#4330782c2931fa9a6941bb471ff3c904f1c3a1cd"
-  integrity sha512-ZVCnzdL2isEk34j+QyFUVT/o3PZJhfbLHm0bV6N4K+2UEUTuba0xDgwYpXgrRiis4DIiBJutw0nPoQ2zgZB1ZA==
+influx@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/influx/-/influx-5.2.0.tgz#18fb7d6fb50fc7f571b99c8e2ea28c4c86aa3ab6"
+  integrity sha512-6hPdW1jPDn9c5IqBeqPvrcile/COyyhEjBIw/cpLhyGCFuu3We8lMtSqYvjVNE+50QGA/zSpYkohjrPZ2uW8IA==
 
 inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.3:
   version "2.0.3"


### PR DESCRIPTION
There is now a function in influx-metrics-tracker that will create an influx db for you.
Due to this, Influx needs adding as a dependency.