### PR TITLE
Support custom imports for logical types

### DIFF
--- a/packages/avro-ts-cli/README.md
+++ b/packages/avro-ts-cli/README.md
@@ -21,6 +21,12 @@ Logical types are also supported:
 yarn avro-ts convert avro/*.avsc --logical-type date=string --logical-type timestamp-millis=string
 ```
 
+And custom imports:
+
+```bash
+yarn avro-ts convert avro/*.avsc --logical-type date=Decimal --logical-type-import "Decimal='import { Decimal } from 'my-library'"
+```
+
 ## Running the tests
 
 You can run the tests with:

--- a/packages/avro-ts-cli/package.json
+++ b/packages/avro-ts-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ovotech/avro-ts-cli",
   "description": "A cli to convert avro schemas into typescript interfaces",
-  "version": "1.1.4",
+  "version": "1.1.0",
   "main": "dist/index.js",
   "source": "src/index.ts",
   "types": "dist/index.d.ts",

--- a/packages/avro-ts-cli/package.json
+++ b/packages/avro-ts-cli/package.json
@@ -19,7 +19,7 @@
     "avro-ts-cli": "ts-node src/cli.ts"
   },
   "dependencies": {
-    "@ovotech/avro-ts": "^1.1.1",
+    "@ovotech/avro-ts": "^1.2.0",
     "yargs": "^13.2.4"
   },
   "devDependencies": {

--- a/packages/avro-ts-cli/package.json
+++ b/packages/avro-ts-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ovotech/avro-ts-cli",
   "description": "A cli to convert avro schemas into typescript interfaces",
-  "version": "1.0.4",
+  "version": "1.1.4",
   "main": "dist/index.js",
   "source": "src/index.ts",
   "types": "dist/index.d.ts",

--- a/packages/avro-ts-cli/test/__snapshots__/cli.spec.ts.snap
+++ b/packages/avro-ts-cli/test/__snapshots__/cli.spec.ts.snap
@@ -104,6 +104,10 @@ export interface AccountMigrationCancelledEvent {
      */
     effectiveEnrollmentDate: number;
     /**
+     * Because dates as Decimal are the best!
+     */
+    effectiveEnrollmentDateAsDecimal: number;
+    /**
      * The time when the migration was cancelled (in epoch millis)
      */
     cancelledAt: number;
@@ -346,6 +350,10 @@ export interface AccountMigrationCancelledEvent {
      */
     effectiveEnrollmentDate: string;
     /**
+     * Because dates as Decimal are the best!
+     */
+    effectiveEnrollmentDateAsDecimal: number;
+    /**
      * The time when the migration was cancelled (in epoch millis)
      */
     cancelledAt: string;
@@ -484,6 +492,203 @@ export interface BalanceRetrievedMigrationEvent {
 }"
 `;
 
+exports[`Cli Should convert files with logical types and imports 1`] = `
+"import { Decimal } from 'decimal.js'
+
+export interface AccountMigrationEvent {
+    event: {
+        \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": AccountMigrationCancelledEvent;
+    } | {
+        \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": AccountMigrationCompletedEvent;
+    } | {
+        \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": AccountMigrationRollBackInitiatedEvent;
+    } | {
+        \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": AccountMigrationRolledBackEvent;
+    } | {
+        \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": AccountMigrationScheduledEvent;
+    } | {
+        \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": AccountMigrationValidatedEvent;
+    } | {
+        \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": BalanceRetrievedMigrationEvent;
+    };
+}
+
+export interface EventMetadata {
+    /**
+     * A globally unique ID for this Kafka message
+     */
+    eventId: string;
+    /**
+     * An ID that can be used to link all the requests and Kafka messages in a given transaction. If you already have a trace token from a previous event/request, you should copy it here. If this is the very start of a transaction, you should generate a fresh trace token and put it here. A UUID is suitable
+     */
+    traceToken: string;
+    /**
+     * A timestamp for when the event was created (in epoch millis)
+     */
+    createdAt: number;
+}
+
+export interface AccountMigrationCancelledEvent {
+    metadata: EventMetadata;
+    /**
+     * Globally unique identifier for the enrollment
+     */
+    enrollmentId: string;
+    /**
+     * Unique identifier for the customer. GentrackId/SiemensId. Usually 7 digits.
+     */
+    accountId: string;
+    /**
+     * The unique national reference for Meter Point Administration Number
+     */
+    mpan: string;
+    /**
+     * The date when the account is going to be enrolled for the new balance platform (in epoch days)
+     */
+    effectiveEnrollmentDate: Decimal;
+    /**
+     * Because dates as Decimal are the best!
+     */
+    effectiveEnrollmentDateAsDecimal: number;
+    /**
+     * The time when the migration was cancelled (in epoch millis)
+     */
+    cancelledAt: number;
+}
+
+export interface AccountMigrationCompletedEvent {
+    metadata: EventMetadata;
+    /**
+     * Globally unique identifier for the enrollment
+     */
+    enrollmentId: string;
+    /**
+     * Unique identifier for the customer. GentrackId/SiemensId. Usually 7 digits.
+     */
+    accountId: string;
+    /**
+     * The date when the account is going to be enrolled for the new balance platform (in epoch days)
+     */
+    effectiveEnrollmentDate: Decimal;
+    /**
+     * The time when the migration was completed (in epoch millis)
+     */
+    completedAt: number;
+}
+
+export interface AccountMigrationRollBackInitiatedEvent {
+    metadata: EventMetadata;
+    /**
+     * Globally unique identifier for the enrollment
+     */
+    enrollmentId: string;
+    /**
+     * Unique identifier for the customer. GentrackId/SiemensId. Usually 7 digits.
+     */
+    accountId: string;
+    /**
+     * The date when the account is going to be enrolled for the new balance platform (in epoch days)
+     */
+    effectiveEnrollmentDate: Decimal;
+    /**
+     * The time when the migration rollback was initiated (in epoch millis)
+     */
+    rollBackInitiatedAt: number;
+}
+
+export interface AccountMigrationRolledBackEvent {
+    metadata: EventMetadata;
+    /**
+     * Globally unique identifier for the enrollment
+     */
+    enrollmentId: string;
+    /**
+     * Unique identifier for the customer. GentrackId/SiemensId. Usually 7 digits.
+     */
+    accountId: string;
+    /**
+     * The date when the account is going to be enrolled for the new balance platform (in epoch days)
+     */
+    effectiveEnrollmentDate: Decimal;
+    /**
+     * The time when the migration was rolled back (in epoch millis)
+     */
+    rolledBackAt: number;
+}
+
+export interface AccountMigrationScheduledEvent {
+    metadata: EventMetadata;
+    /**
+     * Globally unique identifier for the enrollment
+     */
+    enrollmentId: string;
+    /**
+     * Unique identifier for the customer. GentrackId/SiemensId. Usually 7 digits.
+     */
+    accountId: string;
+    /**
+     * The unique national reference for Meter Point Administration Number
+     */
+    mpan: string;
+    /**
+     * The date when the customer came on supply with Boost (in epoch days)
+     */
+    supplyStartDate: Decimal;
+    /**
+     * The date when the account is going to be enrolled for the new balance platform (in epoch days)
+     */
+    effectiveEnrollmentDate: Decimal;
+    /**
+     * The time when the migration was scheduled (in epoch millis)
+     */
+    scheduledAt: number;
+}
+
+export interface AccountMigrationValidatedEvent {
+    metadata: EventMetadata;
+    /**
+     * Globally unique identifier for the enrollment
+     */
+    enrollmentId: string;
+    /**
+     * Unique identifier for the customer. GentrackId/SiemensId. Usually 7 digits.
+     */
+    accountId: string;
+    /**
+     * The date when the account is going to be enrolled for the new balance platform (in epoch days)
+     */
+    effectiveEnrollmentDate: Decimal;
+    /**
+     * The time when the migrated balance and transactions were validated (in epoch millis)
+     */
+    validatedAt: number;
+}
+
+export interface BalanceRetrievedMigrationEvent {
+    metadata: EventMetadata;
+    /**
+     * Globally unique identifier for the enrollment
+     */
+    enrollmentId: string;
+    /**
+     * Unique identifier for the customer. GentrackId/SiemensId. Usually 7 digits.
+     */
+    accountId: string;
+    /**
+     * The unique national reference for Meter Point Administration Number
+     */
+    mpan: string;
+    /**
+     * The date when the account is going to be enrolled for the new balance platform (in epoch days)
+     */
+    effectiveEnrollmentDate: Decimal;
+    /**
+     * The time when the balance and transaction history was fetched (in epoch millis)
+     */
+    retrievedAt: number;
+}"
+`;
+
 exports[`Cli Should convert multiple files 1`] = `
 "export interface User {
     /**
@@ -587,6 +792,10 @@ export interface AccountMigrationCancelledEvent {
      * The date when the account is going to be enrolled for the new balance platform (in epoch days)
      */
     effectiveEnrollmentDate: number;
+    /**
+     * Because dates as Decimal are the best!
+     */
+    effectiveEnrollmentDateAsDecimal: number;
     /**
      * The time when the migration was cancelled (in epoch millis)
      */

--- a/packages/avro-ts-cli/test/avro/ComplexUnionLogicalTypes.avsc
+++ b/packages/avro-ts-cli/test/avro/ComplexUnionLogicalTypes.avsc
@@ -65,6 +65,14 @@
               "doc": "The date when the account is going to be enrolled for the new balance platform (in epoch days)"
             },
             {
+              "name": "effectiveEnrollmentDateAsDecimal",
+              "type": {
+                "type": "int",
+                "logicalType": "Decimal"
+              },
+              "doc": "Because dates as Decimal are the best!"
+            },
+            {
               "name": "cancelledAt",
               "type": {
                 "type": "long",

--- a/packages/avro-ts-cli/test/cli.spec.ts
+++ b/packages/avro-ts-cli/test/cli.spec.ts
@@ -23,6 +23,7 @@ describe('Cli', () => {
       input: [join(avroDir, 'ComplexRecord.avsc')],
       'output-dir': '',
       'logical-type': [],
+      'logical-type-import': [],
     });
 
     const file = readFileSync(join(avroDir, 'ComplexRecord.avsc.ts'));
@@ -36,6 +37,7 @@ describe('Cli', () => {
       input: [join(avroDir, 'ComplexRecord.avsc'), join(avroDir, 'ComplexUnionLogicalTypes.avsc')],
       'output-dir': '',
       'logical-type': [],
+      'logical-type-import': [],
     });
 
     const file1 = readFileSync(join(avroDir, 'ComplexRecord.avsc.ts'));
@@ -51,6 +53,7 @@ describe('Cli', () => {
       input: [join(avroDir, 'ComplexRecord.avsc'), join(avroDir, 'ComplexUnionLogicalTypes.avsc')],
       'output-dir': generatedDir,
       'logical-type': [],
+      'logical-type-import': [],
     });
 
     const file1 = readFileSync(join(generatedDir, 'ComplexRecord.avsc.ts'));
@@ -66,11 +69,26 @@ describe('Cli', () => {
       input: [join(avroDir, 'ComplexRecord.avsc'), join(avroDir, 'ComplexUnionLogicalTypes.avsc')],
       'output-dir': generatedDir,
       'logical-type': ['timestamp-millis=string', 'date=string'],
+      'logical-type-import': [],
     });
 
     const file1 = readFileSync(join(generatedDir, 'ComplexRecord.avsc.ts'));
     const file2 = readFileSync(join(generatedDir, 'ComplexUnionLogicalTypes.avsc.ts'));
     expect(String(file1)).toMatchSnapshot();
+    expect(String(file2)).toMatchSnapshot();
+  });
+
+  it('Should convert files with logical types and imports', async () => {
+    await convertCommand.handler({
+      _: [],
+      $0: '',
+      input: [join(avroDir, 'ComplexRecord.avsc'), join(avroDir, 'ComplexUnionLogicalTypes.avsc')],
+      'output-dir': generatedDir,
+      'logical-type': ['date=Decimal'],
+      'logical-type-import': ["date=import { Decimal } from 'decimal.js'"],
+    });
+
+    const file2 = readFileSync(join(generatedDir, 'ComplexUnionLogicalTypes.avsc.ts'));
     expect(String(file2)).toMatchSnapshot();
   });
 
@@ -81,6 +99,7 @@ describe('Cli', () => {
       input: [join(avroDir, 'ComplexRecord.avsc')],
       'output-dir': 'unknown-folder',
       'logical-type': [],
+      'logical-type-import': [],
     });
 
     await expect(result).rejects.toMatchObject({

--- a/packages/avro-ts/README.md
+++ b/packages/avro-ts/README.md
@@ -17,7 +17,14 @@ import { schema } from 'avsc';
 import { avroTs } from '@ovotech/avro-ts';
 
 const avro: schema.RecordType = JSON.parse(String(readFileSync(join(__dirname, 'avro', file))));
-const ts = avroTs(avro, { 'timestamp-millis': 'string', date: 'string' });
+const ts = avroTs(avro, {
+  'timestamp-millis': 'string',
+  date: 'string',
+  decimal: {
+    type: 'Decimal',
+    import: "import { Decimal } from 'decimal.js'",
+  },
+});
 
 console.log(ts);
 ```

--- a/packages/avro-ts/package.json
+++ b/packages/avro-ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ovotech/avro-ts",
   "description": "Convert avro schemas into typescript interfaces",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "main": "dist/index.js",
   "source": "src/index.ts",
   "types": "dist/index.d.ts",

--- a/packages/avro-ts/src/index.ts
+++ b/packages/avro-ts/src/index.ts
@@ -255,11 +255,21 @@ const fullyQualifiedName = (context: Context, type: schema.RecordType) => {
   return currentNamespace ? `${currentNamespace}.${type.name}` : type.name;
 };
 
-export const printAstNode = (importLines: Array<string>, node: Result): string => {
+export const printAstNode = (node: Result): string => {
+  console.error(
+    'DEPRECATED',
+    'printAstNode() will soon not be exported anymore. See the official Typescript documentation for steps to write your own. https://github.com/Microsoft/TypeScript/wiki/Using-the-Compiler-API#creating-and-printing-a-typescript-ast',
+  );
+  return printAstNodeFullyFeatured(node);
+};
+
+const printAstNodeFullyFeatured = (node: Result, extras: { importLines?: Array<string> } = {}): string => {
   const resultFile = ts.createSourceFile('someFileName.ts', '', ts.ScriptTarget.Latest);
   const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
   const entries = Object.values(node.context.registry);
   const fullSourceFile = ts.updateSourceFileNode(resultFile, entries);
+
+  const importLines = extras.importLines || [];
 
   return importLines
     .concat(
@@ -295,5 +305,5 @@ export function avroTs(
     .map(visitedType => (logicalTypes[visitedType] as LogicalTypeWithImport).import)
     .filter(Boolean);
 
-  return printAstNode(importLines, node);
+  return printAstNodeFullyFeatured(node, { importLines });
 }

--- a/packages/avro-ts/src/index.ts
+++ b/packages/avro-ts/src/index.ts
@@ -11,6 +11,7 @@ export interface Context {
   namespace?: string;
   namespaces: { [key: string]: ts.TypeReferenceNode };
   logicalTypes: { [key: string]: ts.TypeReferenceNode };
+  visitedLogicalTypes: Array<string>;
 }
 
 export interface Result<TsType = ts.TypeNode> {
@@ -163,10 +164,13 @@ const convertEnum: Convert<schema.EnumType> = (context, enumType) =>
     ts.createUnionTypeNode(enumType.symbols.map(symbol => ts.createLiteralTypeNode(ts.createLiteral(symbol)))),
   );
 
-const convertLogicalType: Convert<schema.LogicalType> = (context, type) =>
-  context.logicalTypes[type.logicalType]
-    ? result(context, context.logicalTypes[type.logicalType])
-    : convertPrimitive(context, type.type);
+const convertLogicalType: Convert<schema.LogicalType> = (context, type) => {
+  if (context.logicalTypes[type.logicalType]) {
+    if (!context.visitedLogicalTypes.includes(type.logicalType)) context.visitedLogicalTypes.push(type.logicalType);
+    return result(context, context.logicalTypes[type.logicalType]);
+  }
+  return convertPrimitive(context, type.type);
+};
 
 const convertPredefinedType: Convert<string> = (context, type) =>
   context.namespaces[type] ? result(context, context.namespaces[type]) : convertPrimitive(context, type);
@@ -251,28 +255,45 @@ const fullyQualifiedName = (context: Context, type: schema.RecordType) => {
   return currentNamespace ? `${currentNamespace}.${type.name}` : type.name;
 };
 
-export const printAstNode = (node: Result): string => {
+export const printAstNode = (importLines: Array<string>, node: Result): string => {
   const resultFile = ts.createSourceFile('someFileName.ts', '', ts.ScriptTarget.Latest);
   const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
   const entries = Object.values(node.context.registry);
   const fullSourceFile = ts.updateSourceFileNode(resultFile, entries);
 
-  return [
-    printer.printNode(ts.EmitHint.Unspecified, node.type, fullSourceFile),
-    ...entries.map(entry => printer.printNode(ts.EmitHint.Unspecified, entry, fullSourceFile)),
-  ].join('\n\n');
+  return importLines
+    .concat(
+      printer.printNode(ts.EmitHint.Unspecified, node.type, fullSourceFile),
+      entries.map(entry => printer.printNode(ts.EmitHint.Unspecified, entry, fullSourceFile)),
+    )
+    .join('\n\n');
 };
 
-export function avroTs(recordType: schema.RecordType, logicalTypes: { [key: string]: string } = {}): string {
+type LogicalTypeWithImport = { import: string; type: string };
+type LogicalTypeDefinition = string | LogicalTypeWithImport;
+
+export function avroTs(
+  recordType: schema.RecordType,
+  logicalTypes: { [key: string]: LogicalTypeDefinition } = {},
+): string {
   const context: Context = {
     root: true,
     registry: {},
     namespaces: {},
-    logicalTypes: Object.entries(logicalTypes).reduce(
-      (all, [name, type]) => ({ ...all, [name]: ts.createTypeReferenceNode(type, undefined) }),
-      {},
-    ),
+    visitedLogicalTypes: [],
+    logicalTypes: Object.entries(logicalTypes).reduce((all, [name, type]) => {
+      const typeStr = (type as LogicalTypeWithImport).type ? (type as LogicalTypeWithImport).type : (type as string);
+      return {
+        ...all,
+        [name]: ts.createTypeReferenceNode(typeStr, undefined),
+      };
+    }, {}),
   };
 
-  return printAstNode(convertRecord(context, recordType));
+  const node = convertRecord(context, recordType);
+  const importLines = context.visitedLogicalTypes
+    .map(visitedType => (logicalTypes[visitedType] as LogicalTypeWithImport).import)
+    .filter(Boolean);
+
+  return printAstNode(importLines, node);
 }

--- a/packages/avro-ts/test/__snapshots__/index.spec.ts.snap
+++ b/packages/avro-ts/test/__snapshots__/index.spec.ts.snap
@@ -403,15 +403,21 @@ exports[`Avro ts test Should convert RecordWithLogicalTypes.avsc successfully 1`
 `;
 
 exports[`Avro ts test Should convert RecordWithLogicalTypesImport.avsc successfully 1`] = `
-"export interface Event {
+"import { Decimal } from 'my-library'
+
+export interface Event {
     /**
      * System-assigned numeric user ID. Cannot be changed by the user.
      */
     id: number;
     /**
-     * A timestamp for when the event was created (in epoch millis)
+     * A Decimal that we need a library for
      */
-    createdAt: number;
+    decimalValue: Decimal;
+    /**
+     * Another decimal to make sure we don't add the import more than once
+     */
+    anotherDecimal: Decimal;
 }"
 `;
 

--- a/packages/avro-ts/test/__snapshots__/index.spec.ts.snap
+++ b/packages/avro-ts/test/__snapshots__/index.spec.ts.snap
@@ -402,6 +402,19 @@ exports[`Avro ts test Should convert RecordWithLogicalTypes.avsc successfully 1`
 }"
 `;
 
+exports[`Avro ts test Should convert RecordWithLogicalTypesImport.avsc successfully 1`] = `
+"export interface Event {
+    /**
+     * System-assigned numeric user ID. Cannot be changed by the user.
+     */
+    id: number;
+    /**
+     * A timestamp for when the event was created (in epoch millis)
+     */
+    createdAt: number;
+}"
+`;
+
 exports[`Avro ts test Should convert RecordWithMap.avsc successfully 1`] = `
 "export interface User {
     /**

--- a/packages/avro-ts/test/avro/RecordWithLogicalTypesImport.avsc
+++ b/packages/avro-ts/test/avro/RecordWithLogicalTypesImport.avsc
@@ -1,0 +1,29 @@
+{
+  "type": "record",
+  "name": "Event",
+  "namespace": "com.example.avro",
+  "doc": "This is a user record in a fictitious to-do-list management app. It supports arbitrary grouping and nesting of items, and allows you to add items by email or by tweeting.\n\nNote this app doesn't actually exist. The schema is just a demo for [Avrodoc](https://github.com/ept/avrodoc)!",
+  "fields": [
+    {
+      "name": "id",
+      "doc": "System-assigned numeric user ID. Cannot be changed by the user.",
+      "type": "int"
+    },
+    {
+      "name": "decimalValue",
+      "doc": "A Decimal that we need a library for",
+      "type": {
+        "type": "long",
+        "logicalType": "decimal"
+      }
+    },
+    {
+      "name": "anotherDecimal",
+      "doc": "Another decimal to make sure we don't add the import more than once",
+      "type": {
+        "type": "long",
+        "logicalType": "decimal"
+      }
+    }
+  ]
+}

--- a/packages/avro-ts/test/index.spec.ts
+++ b/packages/avro-ts/test/index.spec.ts
@@ -14,7 +14,11 @@ describe('Avro ts test', () => {
 
   it.each(avscFiles)('Should convert %s successfully', file => {
     const avro: schema.RecordType = JSON.parse(String(readFileSync(join(__dirname, 'avro', file))));
-    const ts = avroTs(avro, { 'timestamp-millis': 'string', date: 'string' });
+    const ts = avroTs(avro, {
+      'timestamp-millis': 'string',
+      date: 'string',
+      decimal: { import: "import { Decimal } from 'my-library'", type: 'Decimal' },
+    });
     expect(ts).toMatchSnapshot();
     writeFileSync(join(__dirname, '__generated__', file + '.ts'), ts);
   });


### PR DESCRIPTION
We have logical types that require import statements (exact example in the README changes).

The solution for this feels pretty hacky, and the resulting imports might not be pretty, but I reckon this might be an acceptable solution?

I went for `string` for the `import` property for 2 reasons:
- Not leaking AST knowledge requirements to the caller of this tool
- Easier integration with `avro-ts-cli`, which I plan to do as part of this PR depending on feedback.