### PR TITLE
Export keycloak-auth types from root

### DIFF
--- a/packages/keycloak-auth/package.json
+++ b/packages/keycloak-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ovotech/keycloak-auth",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "main": "dist/index.js",
   "source": "src/index.ts",
   "types": "dist/index.d.ts",

--- a/packages/keycloak-auth/src/index.ts
+++ b/packages/keycloak-auth/src/index.ts
@@ -1,5 +1,5 @@
 export { KeycloakAuthError } from './KeycloakAuthError';
-export { login, refresh, authenticate, AuthResponse, isExpired } from './api';
-export { KeycloakAuth } from './KeycloakAuth';
-export { keycloakAxios } from './keycloakAxios';
+export { login, refresh, authenticate, AuthResponse, isExpired, KeycloakResponse } from './api';
+export { KeycloakAuth, KeycloakAuthOptions } from './KeycloakAuth';
+export { keycloakAxios, KeycloakAxiosOptions } from './keycloakAxios';
 export { decodeAccessToken, BouncerConfig } from './KeycloakBouncer';


### PR DESCRIPTION
These interfaces were already exported from their respective locations.
This makes them easier to use in consuming code.