### PR TITLE
 Allow keycloakAxios to take a KeycloakAuth

### DIFF
--- a/packages/keycloak-auth/package.json
+++ b/packages/keycloak-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ovotech/keycloak-auth",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "main": "dist/index.js",
   "source": "src/index.ts",
   "types": "dist/index.d.ts",

--- a/packages/keycloak-auth/src/index.ts
+++ b/packages/keycloak-auth/src/index.ts
@@ -1,5 +1,5 @@
 export { KeycloakAuthError } from './KeycloakAuthError';
 export { login, refresh, authenticate, AuthResponse, isExpired, KeycloakResponse } from './api';
 export { KeycloakAuth, KeycloakAuthOptions } from './KeycloakAuth';
-export { keycloakAxios, keycloakAxiosInterceptor, KeycloakAxiosOptions } from './keycloakAxios';
+export { keycloakAxios, KeycloakAxiosOptions } from './keycloakAxios';
 export { decodeAccessToken, BouncerConfig } from './KeycloakBouncer';

--- a/packages/keycloak-auth/src/index.ts
+++ b/packages/keycloak-auth/src/index.ts
@@ -1,5 +1,5 @@
 export { KeycloakAuthError } from './KeycloakAuthError';
 export { login, refresh, authenticate, AuthResponse, isExpired, KeycloakResponse } from './api';
 export { KeycloakAuth, KeycloakAuthOptions } from './KeycloakAuth';
-export { keycloakAxios, KeycloakAxiosOptions } from './keycloakAxios';
+export { keycloakAxios, keycloakAxiosInterceptor, KeycloakAxiosOptions } from './keycloakAxios';
 export { decodeAccessToken, BouncerConfig } from './KeycloakBouncer';

--- a/packages/keycloak-auth/src/keycloakAxios.ts
+++ b/packages/keycloak-auth/src/keycloakAxios.ts
@@ -1,5 +1,6 @@
 import { AxiosRequestConfig } from 'axios';
 import { authenticate, AuthResponse } from './api';
+import { KeycloakAuth } from './KeycloakAuth';
 
 export interface KeycloakAxiosOptions {
   serverUrl: string;
@@ -8,11 +9,18 @@ export interface KeycloakAxiosOptions {
   margin?: number;
 }
 
-export const keycloakAxios = (options: KeycloakAxiosOptions) => {
-  let previous: AuthResponse;
+export const keycloakAxios = (input: KeycloakAxiosOptions | KeycloakAuth) => {
+  if (input instanceof KeycloakAuth) {
+    return async (config: AxiosRequestConfig) => {
+      const authResponse = await input.authenticate();
+      config.headers.Authorization = `Bearer ${authResponse.accessToken}`;
+      return config;
+    };
+  }
 
+  let previous: AuthResponse;
   return async (config: AxiosRequestConfig) => {
-    previous = await authenticate({ ...options, previous });
+    previous = await authenticate({ ...input, previous });
     config.headers.Authorization = `Bearer ${previous.accessToken}`;
     return config;
   };


### PR DESCRIPTION
Previously, keycloakAxios only allowed a specific config object to be passed in. This leads to various usage issues around how values are passed around and tested.

By allowing a KeycloakAuth to be passed in, implementation details around axios can be better hidden. The existing function has been overloaded to prevent having two functions with different names but the exact same functionality.