### PR TITLE
V2: Support top level union 

### DIFF
--- a/packages/avro-ts-cli/package.json
+++ b/packages/avro-ts-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ovotech/avro-ts-cli",
   "description": "A cli to convert avro schemas into typescript interfaces",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "main": "dist/index.js",
   "source": "src/index.ts",
   "types": "dist/index.d.ts",

--- a/packages/avro-ts-cli/package.json
+++ b/packages/avro-ts-cli/package.json
@@ -19,7 +19,7 @@
     "avro-ts-cli": "ts-node src/cli.ts"
   },
   "dependencies": {
-    "@ovotech/avro-ts": "^1.2.0",
+    "@ovotech/avro-ts": "^2.0.0",
     "yargs": "^13.2.4"
   },
   "devDependencies": {

--- a/packages/avro-ts-cli/src/convertCommand.ts
+++ b/packages/avro-ts-cli/src/convertCommand.ts
@@ -2,7 +2,7 @@ import { avroTs } from '@ovotech/avro-ts';
 import chalk from 'chalk';
 import { readFileSync, writeFileSync } from 'fs';
 import { basename, join } from 'path';
-import { Arguments, CommandModule } from 'yargs';
+import { CommandModule } from 'yargs';
 
 export interface ConvertTags {
   input: string[];
@@ -32,6 +32,14 @@ export const convertCommand: CommandModule<{}, ConvertTags> = {
       type: 'array',
       default: [],
     },
+    ['record-alias']: {
+      description: 'What name to give the exported Record type',
+      default: 'Record',
+    },
+    ['namespace-prefix']: {
+      description: 'What prefix to use for the name of namespaced types',
+      default: 'Namespaced',
+    },
   },
   describe: 'Convert avsc to typescript files',
   handler: async args => {
@@ -42,7 +50,9 @@ export const convertCommand: CommandModule<{}, ConvertTags> = {
 
     for (const file of args.input) {
       const avroSchema = JSON.parse(String(readFileSync(file)));
-      const ts = avroTs(avroSchema, mergeTypesAndImport(rawLogicalTypes, logicalTypeImports));
+      const ts = avroTs(avroSchema, {
+        logicalTypes: mergeTypesAndImport(rawLogicalTypes, logicalTypeImports),
+      });
       const outputFile = args['output-dir'] ? join(args['output-dir'], `${basename(file)}.ts`) : `${file}.ts`;
       writeFileSync(outputFile, ts);
 

--- a/packages/avro-ts-cli/test/__snapshots__/cli.spec.ts.snap
+++ b/packages/avro-ts-cli/test/__snapshots__/cli.spec.ts.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Cli Should convert files into output folder file 1`] = `
-"export interface User {
+"export type Record = User;
+
+export interface User {
     /**
      * System-assigned numeric user ID. Cannot be changed by the user.
      */
@@ -52,37 +54,10 @@ export interface EmailAddress {
 `;
 
 exports[`Cli Should convert files into output folder file 2`] = `
-"export interface AccountMigrationEvent {
-    event: {
-        \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": AccountMigrationCancelledEvent;
-    } | {
-        \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": AccountMigrationCompletedEvent;
-    } | {
-        \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": AccountMigrationRollBackInitiatedEvent;
-    } | {
-        \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": AccountMigrationRolledBackEvent;
-    } | {
-        \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": AccountMigrationScheduledEvent;
-    } | {
-        \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": AccountMigrationValidatedEvent;
-    } | {
-        \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": BalanceRetrievedMigrationEvent;
-    };
-}
+"export type Record = AccountMigrationEvent;
 
-export interface EventMetadata {
-    /**
-     * A globally unique ID for this Kafka message
-     */
-    eventId: string;
-    /**
-     * An ID that can be used to link all the requests and Kafka messages in a given transaction. If you already have a trace token from a previous event/request, you should copy it here. If this is the very start of a transaction, you should generate a fresh trace token and put it here. A UUID is suitable
-     */
-    traceToken: string;
-    /**
-     * A timestamp for when the event was created (in epoch millis)
-     */
-    createdAt: number;
+export interface AccountMigrationEvent {
+    event: NamespacedAccountMigrationCancelledEvent | NamespacedAccountMigrationCompletedEvent | NamespacedAccountMigrationRollBackInitiatedEvent | NamespacedAccountMigrationRolledBackEvent | NamespacedAccountMigrationScheduledEvent | NamespacedAccountMigrationValidatedEvent | NamespacedBalanceRetrievedMigrationEvent;
 }
 
 export interface AccountMigrationCancelledEvent {
@@ -113,6 +88,25 @@ export interface AccountMigrationCancelledEvent {
     cancelledAt: number;
 }
 
+export interface EventMetadata {
+    /**
+     * A globally unique ID for this Kafka message
+     */
+    eventId: string;
+    /**
+     * An ID that can be used to link all the requests and Kafka messages in a given transaction. If you already have a trace token from a previous event/request, you should copy it here. If this is the very start of a transaction, you should generate a fresh trace token and put it here. A UUID is suitable
+     */
+    traceToken: string;
+    /**
+     * A timestamp for when the event was created (in epoch millis)
+     */
+    createdAt: number;
+}
+
+export interface NamespacedAccountMigrationCancelledEvent {
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": AccountMigrationCancelledEvent;
+}
+
 export interface AccountMigrationCompletedEvent {
     metadata: EventMetadata;
     /**
@@ -131,6 +125,10 @@ export interface AccountMigrationCompletedEvent {
      * The time when the migration was completed (in epoch millis)
      */
     completedAt: number;
+}
+
+export interface NamespacedAccountMigrationCompletedEvent {
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": AccountMigrationCompletedEvent;
 }
 
 export interface AccountMigrationRollBackInitiatedEvent {
@@ -153,6 +151,10 @@ export interface AccountMigrationRollBackInitiatedEvent {
     rollBackInitiatedAt: number;
 }
 
+export interface NamespacedAccountMigrationRollBackInitiatedEvent {
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": AccountMigrationRollBackInitiatedEvent;
+}
+
 export interface AccountMigrationRolledBackEvent {
     metadata: EventMetadata;
     /**
@@ -171,6 +173,10 @@ export interface AccountMigrationRolledBackEvent {
      * The time when the migration was rolled back (in epoch millis)
      */
     rolledBackAt: number;
+}
+
+export interface NamespacedAccountMigrationRolledBackEvent {
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": AccountMigrationRolledBackEvent;
 }
 
 export interface AccountMigrationScheduledEvent {
@@ -201,6 +207,10 @@ export interface AccountMigrationScheduledEvent {
     scheduledAt: number;
 }
 
+export interface NamespacedAccountMigrationScheduledEvent {
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": AccountMigrationScheduledEvent;
+}
+
 export interface AccountMigrationValidatedEvent {
     metadata: EventMetadata;
     /**
@@ -219,6 +229,10 @@ export interface AccountMigrationValidatedEvent {
      * The time when the migrated balance and transactions were validated (in epoch millis)
      */
     validatedAt: number;
+}
+
+export interface NamespacedAccountMigrationValidatedEvent {
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": AccountMigrationValidatedEvent;
 }
 
 export interface BalanceRetrievedMigrationEvent {
@@ -243,11 +257,17 @@ export interface BalanceRetrievedMigrationEvent {
      * The time when the balance and transaction history was fetched (in epoch millis)
      */
     retrievedAt: number;
+}
+
+export interface NamespacedBalanceRetrievedMigrationEvent {
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": BalanceRetrievedMigrationEvent;
 }"
 `;
 
 exports[`Cli Should convert files with logical types 1`] = `
-"export interface User {
+"export type Record = User;
+
+export interface User {
     /**
      * System-assigned numeric user ID. Cannot be changed by the user.
      */
@@ -298,37 +318,10 @@ export interface EmailAddress {
 `;
 
 exports[`Cli Should convert files with logical types 2`] = `
-"export interface AccountMigrationEvent {
-    event: {
-        \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": AccountMigrationCancelledEvent;
-    } | {
-        \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": AccountMigrationCompletedEvent;
-    } | {
-        \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": AccountMigrationRollBackInitiatedEvent;
-    } | {
-        \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": AccountMigrationRolledBackEvent;
-    } | {
-        \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": AccountMigrationScheduledEvent;
-    } | {
-        \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": AccountMigrationValidatedEvent;
-    } | {
-        \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": BalanceRetrievedMigrationEvent;
-    };
-}
+"export type Record = AccountMigrationEvent;
 
-export interface EventMetadata {
-    /**
-     * A globally unique ID for this Kafka message
-     */
-    eventId: string;
-    /**
-     * An ID that can be used to link all the requests and Kafka messages in a given transaction. If you already have a trace token from a previous event/request, you should copy it here. If this is the very start of a transaction, you should generate a fresh trace token and put it here. A UUID is suitable
-     */
-    traceToken: string;
-    /**
-     * A timestamp for when the event was created (in epoch millis)
-     */
-    createdAt: string;
+export interface AccountMigrationEvent {
+    event: NamespacedAccountMigrationCancelledEvent | NamespacedAccountMigrationCompletedEvent | NamespacedAccountMigrationRollBackInitiatedEvent | NamespacedAccountMigrationRolledBackEvent | NamespacedAccountMigrationScheduledEvent | NamespacedAccountMigrationValidatedEvent | NamespacedBalanceRetrievedMigrationEvent;
 }
 
 export interface AccountMigrationCancelledEvent {
@@ -359,6 +352,25 @@ export interface AccountMigrationCancelledEvent {
     cancelledAt: string;
 }
 
+export interface EventMetadata {
+    /**
+     * A globally unique ID for this Kafka message
+     */
+    eventId: string;
+    /**
+     * An ID that can be used to link all the requests and Kafka messages in a given transaction. If you already have a trace token from a previous event/request, you should copy it here. If this is the very start of a transaction, you should generate a fresh trace token and put it here. A UUID is suitable
+     */
+    traceToken: string;
+    /**
+     * A timestamp for when the event was created (in epoch millis)
+     */
+    createdAt: string;
+}
+
+export interface NamespacedAccountMigrationCancelledEvent {
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": AccountMigrationCancelledEvent;
+}
+
 export interface AccountMigrationCompletedEvent {
     metadata: EventMetadata;
     /**
@@ -377,6 +389,10 @@ export interface AccountMigrationCompletedEvent {
      * The time when the migration was completed (in epoch millis)
      */
     completedAt: string;
+}
+
+export interface NamespacedAccountMigrationCompletedEvent {
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": AccountMigrationCompletedEvent;
 }
 
 export interface AccountMigrationRollBackInitiatedEvent {
@@ -399,6 +415,10 @@ export interface AccountMigrationRollBackInitiatedEvent {
     rollBackInitiatedAt: string;
 }
 
+export interface NamespacedAccountMigrationRollBackInitiatedEvent {
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": AccountMigrationRollBackInitiatedEvent;
+}
+
 export interface AccountMigrationRolledBackEvent {
     metadata: EventMetadata;
     /**
@@ -417,6 +437,10 @@ export interface AccountMigrationRolledBackEvent {
      * The time when the migration was rolled back (in epoch millis)
      */
     rolledBackAt: string;
+}
+
+export interface NamespacedAccountMigrationRolledBackEvent {
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": AccountMigrationRolledBackEvent;
 }
 
 export interface AccountMigrationScheduledEvent {
@@ -447,6 +471,10 @@ export interface AccountMigrationScheduledEvent {
     scheduledAt: string;
 }
 
+export interface NamespacedAccountMigrationScheduledEvent {
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": AccountMigrationScheduledEvent;
+}
+
 export interface AccountMigrationValidatedEvent {
     metadata: EventMetadata;
     /**
@@ -465,6 +493,10 @@ export interface AccountMigrationValidatedEvent {
      * The time when the migrated balance and transactions were validated (in epoch millis)
      */
     validatedAt: string;
+}
+
+export interface NamespacedAccountMigrationValidatedEvent {
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": AccountMigrationValidatedEvent;
 }
 
 export interface BalanceRetrievedMigrationEvent {
@@ -489,43 +521,20 @@ export interface BalanceRetrievedMigrationEvent {
      * The time when the balance and transaction history was fetched (in epoch millis)
      */
     retrievedAt: string;
+}
+
+export interface NamespacedBalanceRetrievedMigrationEvent {
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": BalanceRetrievedMigrationEvent;
 }"
 `;
 
 exports[`Cli Should convert files with logical types and imports 1`] = `
 "import { Decimal } from 'decimal.js'
 
-export interface AccountMigrationEvent {
-    event: {
-        \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": AccountMigrationCancelledEvent;
-    } | {
-        \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": AccountMigrationCompletedEvent;
-    } | {
-        \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": AccountMigrationRollBackInitiatedEvent;
-    } | {
-        \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": AccountMigrationRolledBackEvent;
-    } | {
-        \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": AccountMigrationScheduledEvent;
-    } | {
-        \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": AccountMigrationValidatedEvent;
-    } | {
-        \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": BalanceRetrievedMigrationEvent;
-    };
-}
+export type Record = AccountMigrationEvent;
 
-export interface EventMetadata {
-    /**
-     * A globally unique ID for this Kafka message
-     */
-    eventId: string;
-    /**
-     * An ID that can be used to link all the requests and Kafka messages in a given transaction. If you already have a trace token from a previous event/request, you should copy it here. If this is the very start of a transaction, you should generate a fresh trace token and put it here. A UUID is suitable
-     */
-    traceToken: string;
-    /**
-     * A timestamp for when the event was created (in epoch millis)
-     */
-    createdAt: number;
+export interface AccountMigrationEvent {
+    event: NamespacedAccountMigrationCancelledEvent | NamespacedAccountMigrationCompletedEvent | NamespacedAccountMigrationRollBackInitiatedEvent | NamespacedAccountMigrationRolledBackEvent | NamespacedAccountMigrationScheduledEvent | NamespacedAccountMigrationValidatedEvent | NamespacedBalanceRetrievedMigrationEvent;
 }
 
 export interface AccountMigrationCancelledEvent {
@@ -556,6 +565,25 @@ export interface AccountMigrationCancelledEvent {
     cancelledAt: number;
 }
 
+export interface EventMetadata {
+    /**
+     * A globally unique ID for this Kafka message
+     */
+    eventId: string;
+    /**
+     * An ID that can be used to link all the requests and Kafka messages in a given transaction. If you already have a trace token from a previous event/request, you should copy it here. If this is the very start of a transaction, you should generate a fresh trace token and put it here. A UUID is suitable
+     */
+    traceToken: string;
+    /**
+     * A timestamp for when the event was created (in epoch millis)
+     */
+    createdAt: number;
+}
+
+export interface NamespacedAccountMigrationCancelledEvent {
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": AccountMigrationCancelledEvent;
+}
+
 export interface AccountMigrationCompletedEvent {
     metadata: EventMetadata;
     /**
@@ -574,6 +602,10 @@ export interface AccountMigrationCompletedEvent {
      * The time when the migration was completed (in epoch millis)
      */
     completedAt: number;
+}
+
+export interface NamespacedAccountMigrationCompletedEvent {
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": AccountMigrationCompletedEvent;
 }
 
 export interface AccountMigrationRollBackInitiatedEvent {
@@ -596,6 +628,10 @@ export interface AccountMigrationRollBackInitiatedEvent {
     rollBackInitiatedAt: number;
 }
 
+export interface NamespacedAccountMigrationRollBackInitiatedEvent {
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": AccountMigrationRollBackInitiatedEvent;
+}
+
 export interface AccountMigrationRolledBackEvent {
     metadata: EventMetadata;
     /**
@@ -614,6 +650,10 @@ export interface AccountMigrationRolledBackEvent {
      * The time when the migration was rolled back (in epoch millis)
      */
     rolledBackAt: number;
+}
+
+export interface NamespacedAccountMigrationRolledBackEvent {
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": AccountMigrationRolledBackEvent;
 }
 
 export interface AccountMigrationScheduledEvent {
@@ -644,6 +684,10 @@ export interface AccountMigrationScheduledEvent {
     scheduledAt: number;
 }
 
+export interface NamespacedAccountMigrationScheduledEvent {
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": AccountMigrationScheduledEvent;
+}
+
 export interface AccountMigrationValidatedEvent {
     metadata: EventMetadata;
     /**
@@ -662,6 +706,10 @@ export interface AccountMigrationValidatedEvent {
      * The time when the migrated balance and transactions were validated (in epoch millis)
      */
     validatedAt: number;
+}
+
+export interface NamespacedAccountMigrationValidatedEvent {
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": AccountMigrationValidatedEvent;
 }
 
 export interface BalanceRetrievedMigrationEvent {
@@ -686,11 +734,17 @@ export interface BalanceRetrievedMigrationEvent {
      * The time when the balance and transaction history was fetched (in epoch millis)
      */
     retrievedAt: number;
+}
+
+export interface NamespacedBalanceRetrievedMigrationEvent {
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": BalanceRetrievedMigrationEvent;
 }"
 `;
 
 exports[`Cli Should convert multiple files 1`] = `
-"export interface User {
+"export type Record = User;
+
+export interface User {
     /**
      * System-assigned numeric user ID. Cannot be changed by the user.
      */
@@ -741,37 +795,10 @@ export interface EmailAddress {
 `;
 
 exports[`Cli Should convert multiple files 2`] = `
-"export interface AccountMigrationEvent {
-    event: {
-        \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": AccountMigrationCancelledEvent;
-    } | {
-        \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": AccountMigrationCompletedEvent;
-    } | {
-        \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": AccountMigrationRollBackInitiatedEvent;
-    } | {
-        \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": AccountMigrationRolledBackEvent;
-    } | {
-        \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": AccountMigrationScheduledEvent;
-    } | {
-        \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": AccountMigrationValidatedEvent;
-    } | {
-        \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": BalanceRetrievedMigrationEvent;
-    };
-}
+"export type Record = AccountMigrationEvent;
 
-export interface EventMetadata {
-    /**
-     * A globally unique ID for this Kafka message
-     */
-    eventId: string;
-    /**
-     * An ID that can be used to link all the requests and Kafka messages in a given transaction. If you already have a trace token from a previous event/request, you should copy it here. If this is the very start of a transaction, you should generate a fresh trace token and put it here. A UUID is suitable
-     */
-    traceToken: string;
-    /**
-     * A timestamp for when the event was created (in epoch millis)
-     */
-    createdAt: number;
+export interface AccountMigrationEvent {
+    event: NamespacedAccountMigrationCancelledEvent | NamespacedAccountMigrationCompletedEvent | NamespacedAccountMigrationRollBackInitiatedEvent | NamespacedAccountMigrationRolledBackEvent | NamespacedAccountMigrationScheduledEvent | NamespacedAccountMigrationValidatedEvent | NamespacedBalanceRetrievedMigrationEvent;
 }
 
 export interface AccountMigrationCancelledEvent {
@@ -802,6 +829,25 @@ export interface AccountMigrationCancelledEvent {
     cancelledAt: number;
 }
 
+export interface EventMetadata {
+    /**
+     * A globally unique ID for this Kafka message
+     */
+    eventId: string;
+    /**
+     * An ID that can be used to link all the requests and Kafka messages in a given transaction. If you already have a trace token from a previous event/request, you should copy it here. If this is the very start of a transaction, you should generate a fresh trace token and put it here. A UUID is suitable
+     */
+    traceToken: string;
+    /**
+     * A timestamp for when the event was created (in epoch millis)
+     */
+    createdAt: number;
+}
+
+export interface NamespacedAccountMigrationCancelledEvent {
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": AccountMigrationCancelledEvent;
+}
+
 export interface AccountMigrationCompletedEvent {
     metadata: EventMetadata;
     /**
@@ -820,6 +866,10 @@ export interface AccountMigrationCompletedEvent {
      * The time when the migration was completed (in epoch millis)
      */
     completedAt: number;
+}
+
+export interface NamespacedAccountMigrationCompletedEvent {
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": AccountMigrationCompletedEvent;
 }
 
 export interface AccountMigrationRollBackInitiatedEvent {
@@ -842,6 +892,10 @@ export interface AccountMigrationRollBackInitiatedEvent {
     rollBackInitiatedAt: number;
 }
 
+export interface NamespacedAccountMigrationRollBackInitiatedEvent {
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": AccountMigrationRollBackInitiatedEvent;
+}
+
 export interface AccountMigrationRolledBackEvent {
     metadata: EventMetadata;
     /**
@@ -860,6 +914,10 @@ export interface AccountMigrationRolledBackEvent {
      * The time when the migration was rolled back (in epoch millis)
      */
     rolledBackAt: number;
+}
+
+export interface NamespacedAccountMigrationRolledBackEvent {
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": AccountMigrationRolledBackEvent;
 }
 
 export interface AccountMigrationScheduledEvent {
@@ -890,6 +948,10 @@ export interface AccountMigrationScheduledEvent {
     scheduledAt: number;
 }
 
+export interface NamespacedAccountMigrationScheduledEvent {
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": AccountMigrationScheduledEvent;
+}
+
 export interface AccountMigrationValidatedEvent {
     metadata: EventMetadata;
     /**
@@ -908,6 +970,10 @@ export interface AccountMigrationValidatedEvent {
      * The time when the migrated balance and transactions were validated (in epoch millis)
      */
     validatedAt: number;
+}
+
+export interface NamespacedAccountMigrationValidatedEvent {
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": AccountMigrationValidatedEvent;
 }
 
 export interface BalanceRetrievedMigrationEvent {
@@ -932,11 +998,17 @@ export interface BalanceRetrievedMigrationEvent {
      * The time when the balance and transaction history was fetched (in epoch millis)
      */
     retrievedAt: number;
+}
+
+export interface NamespacedBalanceRetrievedMigrationEvent {
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": BalanceRetrievedMigrationEvent;
 }"
 `;
 
 exports[`Cli Should convert single file 1`] = `
-"export interface User {
+"export type Record = User;
+
+export interface User {
     /**
      * System-assigned numeric user ID. Cannot be changed by the user.
      */

--- a/packages/avro-ts/README.md
+++ b/packages/avro-ts/README.md
@@ -18,12 +18,16 @@ import { avroTs } from '@ovotech/avro-ts';
 
 const avro: schema.RecordType = JSON.parse(String(readFileSync(join(__dirname, 'avro', file))));
 const ts = avroTs(avro, {
-  'timestamp-millis': 'string',
-  date: 'string',
-  decimal: {
-    type: 'Decimal',
-    import: "import { Decimal } from 'decimal.js'",
+  logicalTypes: {
+    'timestamp-millis': 'string',
+    date: 'string',
+    decimal: {
+      type: 'Decimal',
+      import: "import { Decimal } from 'decimal.js'",
+    },
   },
+  recordAlias: 'Record',
+  namespacedPrefix: 'Namespaced',
 });
 
 console.log(ts);
@@ -40,6 +44,7 @@ This converter currently supports
 - Enum
 - Map
 - Array
+- Root-level union types
 
 ## Running the tests
 

--- a/packages/avro-ts/package.json
+++ b/packages/avro-ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ovotech/avro-ts",
   "description": "Convert avro schemas into typescript interfaces",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "main": "dist/index.js",
   "source": "src/index.ts",
   "types": "dist/index.d.ts",

--- a/packages/avro-ts/test/__snapshots__/index.spec.ts.snap
+++ b/packages/avro-ts/test/__snapshots__/index.spec.ts.snap
@@ -1,22 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Avro ts test Should convert BalanceAdjustment.avsc successfully 1`] = `
-"export interface BalanceAdjustment {
+"export type Record = BalanceAdjustment;
+
+export interface BalanceAdjustment {
     metadata: EventMetadata;
-    event: {
-        \\"uk.co.boostpower.support.kafka.messages.BalanceAdjustmentRequest\\": BalanceAdjustmentRequest;
-    } | {
-        \\"uk.co.boostpower.support.kafka.messages.BalanceAdjustmentResponse\\": BalanceAdjustmentResponse;
-    };
-}
-
-export interface Config {
-    tokenId: string;
-}
-
-export interface ConfigExtended {
-    tokenId: string;
-    extensionId: string;
+    event: NamespacedBalanceAdjustmentRequest | NamespacedBalanceAdjustmentResponse;
 }
 
 export interface EventMetadata {
@@ -32,11 +21,24 @@ export interface EventMetadata {
      * A timestamp for when the event was created (in epoch millis)
      */
     createdAt: string;
-    config: {
-        \\"com.ovoenergy.kafka.common.event.Config\\": Config;
-    } | {
-        \\"com.ovoenergy.kafka.common.event.ConfigExtended\\": ConfigExtended;
-    };
+    config: NamespacedConfig | NamespacedConfigExtended;
+}
+
+export interface Config {
+    tokenId: string;
+}
+
+export interface NamespacedConfig {
+    \\"com.ovoenergy.kafka.common.event.Config\\": Config;
+}
+
+export interface ConfigExtended {
+    tokenId: string;
+    extensionId: string;
+}
+
+export interface NamespacedConfigExtended {
+    \\"com.ovoenergy.kafka.common.event.ConfigExtended\\": ConfigExtended;
 }
 
 export interface BalanceAdjustmentRequest {
@@ -66,6 +68,10 @@ export interface BalanceAdjustmentRequest {
     amount: number;
 }
 
+export interface NamespacedBalanceAdjustmentRequest {
+    \\"uk.co.boostpower.support.kafka.messages.BalanceAdjustmentRequest\\": BalanceAdjustmentRequest;
+}
+
 export interface BalanceAdjustmentResponse {
     /**
      * A unique adjustment job id. Will correspond with the jobId S2BalanceAdjustmentRequest
@@ -79,11 +85,17 @@ export interface BalanceAdjustmentResponse {
      * The resulting the balance after the adjustemt, in thousands of a penny
      */
     balance: number;
+}
+
+export interface NamespacedBalanceAdjustmentResponse {
+    \\"uk.co.boostpower.support.kafka.messages.BalanceAdjustmentResponse\\": BalanceAdjustmentResponse;
 }"
 `;
 
 exports[`Avro ts test Should convert ComplexRecord.avsc successfully 1`] = `
-"export interface User {
+"export type Record = User;
+
+export interface User {
     /**
      * System-assigned numeric user ID. Cannot be changed by the user.
      */
@@ -134,37 +146,10 @@ export interface EmailAddress {
 `;
 
 exports[`Avro ts test Should convert ComplexUnionLogicalTypes.avsc successfully 1`] = `
-"export interface AccountMigrationEvent {
-    event: {
-        \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": AccountMigrationCancelledEvent;
-    } | {
-        \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": AccountMigrationCompletedEvent;
-    } | {
-        \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": AccountMigrationRollBackInitiatedEvent;
-    } | {
-        \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": AccountMigrationRolledBackEvent;
-    } | {
-        \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": AccountMigrationScheduledEvent;
-    } | {
-        \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": AccountMigrationValidatedEvent;
-    } | {
-        \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": BalanceRetrievedMigrationEvent;
-    };
-}
+"export type Record = AccountMigrationEvent;
 
-export interface EventMetadata {
-    /**
-     * A globally unique ID for this Kafka message
-     */
-    eventId: string;
-    /**
-     * An ID that can be used to link all the requests and Kafka messages in a given transaction. If you already have a trace token from a previous event/request, you should copy it here. If this is the very start of a transaction, you should generate a fresh trace token and put it here. A UUID is suitable
-     */
-    traceToken: string;
-    /**
-     * A timestamp for when the event was created (in epoch millis)
-     */
-    createdAt: string;
+export interface AccountMigrationEvent {
+    event: NamespacedAccountMigrationCancelledEvent | NamespacedAccountMigrationCompletedEvent | NamespacedAccountMigrationRollBackInitiatedEvent | NamespacedAccountMigrationRolledBackEvent | NamespacedAccountMigrationScheduledEvent | NamespacedAccountMigrationValidatedEvent | NamespacedBalanceRetrievedMigrationEvent;
 }
 
 export interface AccountMigrationCancelledEvent {
@@ -191,6 +176,25 @@ export interface AccountMigrationCancelledEvent {
     cancelledAt: string;
 }
 
+export interface EventMetadata {
+    /**
+     * A globally unique ID for this Kafka message
+     */
+    eventId: string;
+    /**
+     * An ID that can be used to link all the requests and Kafka messages in a given transaction. If you already have a trace token from a previous event/request, you should copy it here. If this is the very start of a transaction, you should generate a fresh trace token and put it here. A UUID is suitable
+     */
+    traceToken: string;
+    /**
+     * A timestamp for when the event was created (in epoch millis)
+     */
+    createdAt: string;
+}
+
+export interface NamespacedAccountMigrationCancelledEvent {
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": AccountMigrationCancelledEvent;
+}
+
 export interface AccountMigrationCompletedEvent {
     metadata: EventMetadata;
     /**
@@ -209,6 +213,10 @@ export interface AccountMigrationCompletedEvent {
      * The time when the migration was completed (in epoch millis)
      */
     completedAt: string;
+}
+
+export interface NamespacedAccountMigrationCompletedEvent {
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": AccountMigrationCompletedEvent;
 }
 
 export interface AccountMigrationRollBackInitiatedEvent {
@@ -231,6 +239,10 @@ export interface AccountMigrationRollBackInitiatedEvent {
     rollBackInitiatedAt: string;
 }
 
+export interface NamespacedAccountMigrationRollBackInitiatedEvent {
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": AccountMigrationRollBackInitiatedEvent;
+}
+
 export interface AccountMigrationRolledBackEvent {
     metadata: EventMetadata;
     /**
@@ -249,6 +261,10 @@ export interface AccountMigrationRolledBackEvent {
      * The time when the migration was rolled back (in epoch millis)
      */
     rolledBackAt: string;
+}
+
+export interface NamespacedAccountMigrationRolledBackEvent {
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": AccountMigrationRolledBackEvent;
 }
 
 export interface AccountMigrationScheduledEvent {
@@ -279,6 +295,10 @@ export interface AccountMigrationScheduledEvent {
     scheduledAt: string;
 }
 
+export interface NamespacedAccountMigrationScheduledEvent {
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": AccountMigrationScheduledEvent;
+}
+
 export interface AccountMigrationValidatedEvent {
     metadata: EventMetadata;
     /**
@@ -297,6 +317,10 @@ export interface AccountMigrationValidatedEvent {
      * The time when the migrated balance and transactions were validated (in epoch millis)
      */
     validatedAt: string;
+}
+
+export interface NamespacedAccountMigrationValidatedEvent {
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": AccountMigrationValidatedEvent;
 }
 
 export interface BalanceRetrievedMigrationEvent {
@@ -321,11 +345,17 @@ export interface BalanceRetrievedMigrationEvent {
      * The time when the balance and transaction history was fetched (in epoch millis)
      */
     retrievedAt: string;
+}
+
+export interface NamespacedBalanceRetrievedMigrationEvent {
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": BalanceRetrievedMigrationEvent;
 }"
 `;
 
 exports[`Avro ts test Should convert RecordWithEnum.avsc successfully 1`] = `
-"export interface User {
+"export type Record = User;
+
+export interface User {
     /**
      * System-assigned numeric user ID. Cannot be changed by the user.
      */
@@ -350,7 +380,9 @@ exports[`Avro ts test Should convert RecordWithEnum.avsc successfully 1`] = `
 `;
 
 exports[`Avro ts test Should convert RecordWithInterface.avsc successfully 1`] = `
-"export interface User {
+"export type Record = User;
+
+export interface User {
     /**
      * System-assigned numeric user ID. Cannot be changed by the user.
      */
@@ -390,7 +422,9 @@ export interface EmailAddress {
 `;
 
 exports[`Avro ts test Should convert RecordWithLogicalTypes.avsc successfully 1`] = `
-"export interface Event {
+"export type Record = Event;
+
+export interface Event {
     /**
      * System-assigned numeric user ID. Cannot be changed by the user.
      */
@@ -404,6 +438,8 @@ exports[`Avro ts test Should convert RecordWithLogicalTypes.avsc successfully 1`
 
 exports[`Avro ts test Should convert RecordWithLogicalTypesImport.avsc successfully 1`] = `
 "import { Decimal } from 'my-library'
+
+export type Record = Event;
 
 export interface Event {
     /**
@@ -422,7 +458,9 @@ export interface Event {
 `;
 
 exports[`Avro ts test Should convert RecordWithMap.avsc successfully 1`] = `
-"export interface User {
+"export type Record = User;
+
+export interface User {
     /**
      * System-assigned numeric user ID. Cannot be changed by the user.
      */
@@ -450,7 +488,9 @@ export interface Foo {
 `;
 
 exports[`Avro ts test Should convert RecordWithUnion.avsc successfully 1`] = `
-"export interface User {
+"export type Record = User;
+
+export interface User {
     /**
      * System-assigned numeric user ID. Cannot be changed by the user.
      */
@@ -472,7 +512,9 @@ exports[`Avro ts test Should convert RecordWithUnion.avsc successfully 1`] = `
 `;
 
 exports[`Avro ts test Should convert SimpleRecord.avsc successfully 1`] = `
-"export interface User {
+"export type Record = User;
+
+export interface User {
     /**
      * System-assigned numeric user ID. Cannot be changed by the user.
      */
@@ -492,8 +534,36 @@ exports[`Avro ts test Should convert SimpleRecord.avsc successfully 1`] = `
 }"
 `;
 
+exports[`Avro ts test Should convert TopLevelUnion.avsc successfully 1`] = `
+"export type Record = NamespacedCancelled | NamespacedCreation;
+
+export interface Cancelled {
+    metadata: EventMetadata;
+    CancellationId: string;
+}
+
+export interface EventMetadata {
+    eventId: string;
+}
+
+export interface NamespacedCancelled {
+    \\"com.example.avro.Cancelled\\": Cancelled;
+}
+
+export interface Creation {
+    metadata: EventMetadata;
+    creationId: string;
+}
+
+export interface NamespacedCreation {
+    \\"com.example.avro.Creation\\": Creation;
+}"
+`;
+
 exports[`Avro ts test Should convert TradeCollection.avsc successfully 1`] = `
-"export interface TradeCollection {
+"export type Record = TradeCollection;
+
+export interface TradeCollection {
     producerId: string;
     exchange: string;
     market: string;
@@ -512,7 +582,9 @@ export interface Trade {
 `;
 
 exports[`Avro ts test Should convert User.avsc successfully 1`] = `
-"export interface User {
+"export type Record = User;
+
+export interface User {
     /**
      * System-assigned numeric user ID. Cannot be changed by the user.
      */
@@ -610,5 +682,31 @@ export interface ToDoItem {
      * List of children of this to-do tree node
      */
     subItems: any[];
+}"
+`;
+
+exports[`Avro ts test supports providing different names for record and namespaced type 1`] = `
+"export type Event = NSCancelled | NSCreation;
+
+export interface Cancelled {
+    metadata: EventMetadata;
+    CancellationId: string;
+}
+
+export interface EventMetadata {
+    eventId: string;
+}
+
+export interface NSCancelled {
+    \\"com.example.avro.Cancelled\\": Cancelled;
+}
+
+export interface Creation {
+    metadata: EventMetadata;
+    creationId: string;
+}
+
+export interface NSCreation {
+    \\"com.example.avro.Creation\\": Creation;
 }"
 `;

--- a/packages/avro-ts/test/avro/TopLevelUnion.avsc
+++ b/packages/avro-ts/test/avro/TopLevelUnion.avsc
@@ -1,0 +1,42 @@
+[
+  {
+    "type": "record",
+    "name": "Cancelled",
+    "namespace": "com.example.avro",
+    "fields": [
+      {
+        "name": "metadata",
+        "type": {
+          "type": "record",
+          "name": "EventMetadata",
+          "namespace": "com.example.avro.event",
+          "fields": [
+            {
+              "name": "eventId",
+              "type": "string"
+            }
+          ]
+        }
+      },
+      {
+        "name": "CancellationId",
+        "type": "string"
+      }
+    ]
+  },
+  {
+    "type": "record",
+    "name": "Creation",
+    "namespace": "com.example.avro",
+    "fields": [
+      {
+        "name": "metadata",
+        "type": "com.example.avro.event.EventMetadata"
+      },
+      {
+        "name": "creationId",
+        "type": "string"
+      }
+    ]
+  }
+]

--- a/packages/avro-ts/test/index.spec.ts
+++ b/packages/avro-ts/test/index.spec.ts
@@ -15,11 +15,25 @@ describe('Avro ts test', () => {
   it.each(avscFiles)('Should convert %s successfully', file => {
     const avro: schema.RecordType = JSON.parse(String(readFileSync(join(__dirname, 'avro', file))));
     const ts = avroTs(avro, {
-      'timestamp-millis': 'string',
-      date: 'string',
-      decimal: { import: "import { Decimal } from 'my-library'", type: 'Decimal' },
+      logicalTypes: {
+        'timestamp-millis': 'string',
+        date: 'string',
+        decimal: { import: "import { Decimal } from 'my-library'", type: 'Decimal' },
+      },
     });
     expect(ts).toMatchSnapshot();
     writeFileSync(join(__dirname, '__generated__', file + '.ts'), ts);
+  });
+
+  it('supports providing different names for record and namespaced type', () => {
+    const file = 'TopLevelUnion.avsc';
+    const avro: schema.RecordType = JSON.parse(String(readFileSync(join(__dirname, 'avro', file))));
+    const ts = avroTs(avro, {
+      recordAlias: 'Event',
+      namespacedPrefix: 'NS',
+    });
+
+    expect(ts).toMatchSnapshot();
+    writeFileSync(join(__dirname, '__generated__', `renamed-${file}.ts`), ts);
   });
 });


### PR DESCRIPTION
I came across a few schemas that use top level union.

Changes:
- Support top level union
- Export `Record` which is either a single type for classic schemas or a union of namespaced types
- All types that needs namespacing are now defined as interfaces and exported (this allowed code reuse)
- Added options to control how to name `Record` and the namespace prefix, because technically somebody could have a schema with a record named `Record` so we would have clashed.
- As I was introducing breaking changes, I figured we might as well action the deprecation notice from #28 