### PR TITLE
Fix chalk error message

### DIFF
--- a/packages/kafka-avro-cli/package.json
+++ b/packages/kafka-avro-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ovotech/kafka-avro-cli",
   "description": "A CLI for inspecting the confluent schema-registry, produce and consume avro kafka events",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "main": "dist/index.js",
   "source": "src/index.ts",
   "types": "dist/index.d.ts",

--- a/packages/kafka-avro-cli/src/cli/commands/consume.ts
+++ b/packages/kafka-avro-cli/src/cli/commands/consume.ts
@@ -54,7 +54,7 @@ export const consume: CommandModule<{}, ConsumeArgs> = {
     const logConsumerProgress = new LogConsumerProgressTransform(!args['output-file']);
 
     const errorHandler = (title: string) => (error: Error) => {
-      process.stderr.write(chalk(`{red Error in ${title} ${error.message}}\n`));
+      process.stderr.write(chalk(`{red Error in ${title}} ${error.message}\n`));
       consumerStream.close(() => {
         process.stderr.write('Consumer closed\n');
       });


### PR DESCRIPTION
For some reason chalk was acting up, throwing its own error and closing
the stream before any consumption could take place.

This should fix that issue.