### PR TITLE
Avro-TS improvementst and bugfixes

### DIFF
--- a/packages/avro-ts-cli/package.json
+++ b/packages/avro-ts-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ovotech/avro-ts-cli",
   "description": "A cli to convert avro schemas into typescript interfaces",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "main": "dist/index.js",
   "source": "src/index.ts",
   "types": "dist/index.d.ts",
@@ -19,7 +19,7 @@
     "avro-ts-cli": "ts-node src/cli.ts"
   },
   "dependencies": {
-    "@ovotech/avro-ts": "^2.0.0",
+    "@ovotech/avro-ts": "^3.0.0",
     "yargs": "^13.2.4"
   },
   "devDependencies": {

--- a/packages/avro-ts-cli/src/convertCommand.ts
+++ b/packages/avro-ts-cli/src/convertCommand.ts
@@ -36,6 +36,10 @@ export const convertCommand: CommandModule<{}, ConvertTags> = {
       description: 'What name to give the exported Record type',
       default: 'Record',
     },
+    ['names-alias']: {
+      description: 'What name to give the exported namespaces containing names reverse lookup',
+      default: 'Names',
+    },
     ['namespace-prefix']: {
       description: 'What prefix to use for the name of namespaced types',
       default: 'Namespaced',
@@ -52,6 +56,9 @@ export const convertCommand: CommandModule<{}, ConvertTags> = {
       const avroSchema = JSON.parse(String(readFileSync(file)));
       const ts = avroTs(avroSchema, {
         logicalTypes: mergeTypesAndImport(rawLogicalTypes, logicalTypeImports),
+        recordAlias: args['record-alias'] as string,
+        namesAlias: args['name-alias'] as string,
+        namespacedPrefix: args['namespacePrefix'] as string,
       });
       const outputFile = args['output-dir'] ? join(args['output-dir'], `${basename(file)}.ts`) : `${file}.ts`;
       writeFileSync(outputFile, ts);

--- a/packages/avro-ts-cli/test/__snapshots__/cli.spec.ts.snap
+++ b/packages/avro-ts-cli/test/__snapshots__/cli.spec.ts.snap
@@ -115,12 +115,12 @@ export interface EventMetadata {
 
 export interface NamespacedAccountMigrationCancelledEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": AccountMigrationCancelledEvent;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\"?: never;
 }
 
 export interface AccountMigrationCompletedEvent {
@@ -145,12 +145,12 @@ export interface AccountMigrationCompletedEvent {
 
 export interface NamespacedAccountMigrationCompletedEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": AccountMigrationCompletedEvent;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\"?: never;
 }
 
 export interface AccountMigrationRollBackInitiatedEvent {
@@ -175,12 +175,12 @@ export interface AccountMigrationRollBackInitiatedEvent {
 
 export interface NamespacedAccountMigrationRollBackInitiatedEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": AccountMigrationRollBackInitiatedEvent;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\"?: never;
 }
 
 export interface AccountMigrationRolledBackEvent {
@@ -205,12 +205,12 @@ export interface AccountMigrationRolledBackEvent {
 
 export interface NamespacedAccountMigrationRolledBackEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": AccountMigrationRolledBackEvent;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\"?: never;
 }
 
 export interface AccountMigrationScheduledEvent {
@@ -243,12 +243,12 @@ export interface AccountMigrationScheduledEvent {
 
 export interface NamespacedAccountMigrationScheduledEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": AccountMigrationScheduledEvent;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\"?: never;
 }
 
 export interface AccountMigrationValidatedEvent {
@@ -273,12 +273,12 @@ export interface AccountMigrationValidatedEvent {
 
 export interface NamespacedAccountMigrationValidatedEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": AccountMigrationValidatedEvent;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\"?: never;
 }
 
 export interface BalanceRetrievedMigrationEvent {
@@ -307,12 +307,12 @@ export interface BalanceRetrievedMigrationEvent {
 
 export interface NamespacedBalanceRetrievedMigrationEvent {
     \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": BalanceRetrievedMigrationEvent;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\"?: never;
 }"
 `;
 
@@ -431,12 +431,12 @@ export interface EventMetadata {
 
 export interface NamespacedAccountMigrationCancelledEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": AccountMigrationCancelledEvent;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\"?: never;
 }
 
 export interface AccountMigrationCompletedEvent {
@@ -461,12 +461,12 @@ export interface AccountMigrationCompletedEvent {
 
 export interface NamespacedAccountMigrationCompletedEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": AccountMigrationCompletedEvent;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\"?: never;
 }
 
 export interface AccountMigrationRollBackInitiatedEvent {
@@ -491,12 +491,12 @@ export interface AccountMigrationRollBackInitiatedEvent {
 
 export interface NamespacedAccountMigrationRollBackInitiatedEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": AccountMigrationRollBackInitiatedEvent;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\"?: never;
 }
 
 export interface AccountMigrationRolledBackEvent {
@@ -521,12 +521,12 @@ export interface AccountMigrationRolledBackEvent {
 
 export interface NamespacedAccountMigrationRolledBackEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": AccountMigrationRolledBackEvent;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\"?: never;
 }
 
 export interface AccountMigrationScheduledEvent {
@@ -559,12 +559,12 @@ export interface AccountMigrationScheduledEvent {
 
 export interface NamespacedAccountMigrationScheduledEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": AccountMigrationScheduledEvent;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\"?: never;
 }
 
 export interface AccountMigrationValidatedEvent {
@@ -589,12 +589,12 @@ export interface AccountMigrationValidatedEvent {
 
 export interface NamespacedAccountMigrationValidatedEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": AccountMigrationValidatedEvent;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\"?: never;
 }
 
 export interface BalanceRetrievedMigrationEvent {
@@ -623,12 +623,12 @@ export interface BalanceRetrievedMigrationEvent {
 
 export interface NamespacedBalanceRetrievedMigrationEvent {
     \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": BalanceRetrievedMigrationEvent;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\"?: never;
 }"
 `;
 
@@ -696,12 +696,12 @@ export interface EventMetadata {
 
 export interface NamespacedAccountMigrationCancelledEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": AccountMigrationCancelledEvent;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\"?: never;
 }
 
 export interface AccountMigrationCompletedEvent {
@@ -726,12 +726,12 @@ export interface AccountMigrationCompletedEvent {
 
 export interface NamespacedAccountMigrationCompletedEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": AccountMigrationCompletedEvent;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\"?: never;
 }
 
 export interface AccountMigrationRollBackInitiatedEvent {
@@ -756,12 +756,12 @@ export interface AccountMigrationRollBackInitiatedEvent {
 
 export interface NamespacedAccountMigrationRollBackInitiatedEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": AccountMigrationRollBackInitiatedEvent;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\"?: never;
 }
 
 export interface AccountMigrationRolledBackEvent {
@@ -786,12 +786,12 @@ export interface AccountMigrationRolledBackEvent {
 
 export interface NamespacedAccountMigrationRolledBackEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": AccountMigrationRolledBackEvent;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\"?: never;
 }
 
 export interface AccountMigrationScheduledEvent {
@@ -824,12 +824,12 @@ export interface AccountMigrationScheduledEvent {
 
 export interface NamespacedAccountMigrationScheduledEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": AccountMigrationScheduledEvent;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\"?: never;
 }
 
 export interface AccountMigrationValidatedEvent {
@@ -854,12 +854,12 @@ export interface AccountMigrationValidatedEvent {
 
 export interface NamespacedAccountMigrationValidatedEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": AccountMigrationValidatedEvent;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\"?: never;
 }
 
 export interface BalanceRetrievedMigrationEvent {
@@ -888,12 +888,12 @@ export interface BalanceRetrievedMigrationEvent {
 
 export interface NamespacedBalanceRetrievedMigrationEvent {
     \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": BalanceRetrievedMigrationEvent;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\"?: never;
 }"
 `;
 
@@ -1012,12 +1012,12 @@ export interface EventMetadata {
 
 export interface NamespacedAccountMigrationCancelledEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": AccountMigrationCancelledEvent;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\"?: never;
 }
 
 export interface AccountMigrationCompletedEvent {
@@ -1042,12 +1042,12 @@ export interface AccountMigrationCompletedEvent {
 
 export interface NamespacedAccountMigrationCompletedEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": AccountMigrationCompletedEvent;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\"?: never;
 }
 
 export interface AccountMigrationRollBackInitiatedEvent {
@@ -1072,12 +1072,12 @@ export interface AccountMigrationRollBackInitiatedEvent {
 
 export interface NamespacedAccountMigrationRollBackInitiatedEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": AccountMigrationRollBackInitiatedEvent;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\"?: never;
 }
 
 export interface AccountMigrationRolledBackEvent {
@@ -1102,12 +1102,12 @@ export interface AccountMigrationRolledBackEvent {
 
 export interface NamespacedAccountMigrationRolledBackEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": AccountMigrationRolledBackEvent;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\"?: never;
 }
 
 export interface AccountMigrationScheduledEvent {
@@ -1140,12 +1140,12 @@ export interface AccountMigrationScheduledEvent {
 
 export interface NamespacedAccountMigrationScheduledEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": AccountMigrationScheduledEvent;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\"?: never;
 }
 
 export interface AccountMigrationValidatedEvent {
@@ -1170,12 +1170,12 @@ export interface AccountMigrationValidatedEvent {
 
 export interface NamespacedAccountMigrationValidatedEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": AccountMigrationValidatedEvent;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\"?: never;
 }
 
 export interface BalanceRetrievedMigrationEvent {
@@ -1204,12 +1204,12 @@ export interface BalanceRetrievedMigrationEvent {
 
 export interface NamespacedBalanceRetrievedMigrationEvent {
     \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": BalanceRetrievedMigrationEvent;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\"?: never;
 }"
 `;
 

--- a/packages/avro-ts-cli/test/__snapshots__/cli.spec.ts.snap
+++ b/packages/avro-ts-cli/test/__snapshots__/cli.spec.ts.snap
@@ -54,7 +54,17 @@ export interface EmailAddress {
 `;
 
 exports[`Cli Should convert files into output folder file 2`] = `
-"export type Record = AccountMigrationEvent;
+"export namespace Names {
+    export const AccountMigrationCancelledEvent = \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\";
+    export const AccountMigrationCompletedEvent = \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\";
+    export const AccountMigrationRollBackInitiatedEvent = \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\";
+    export const AccountMigrationRolledBackEvent = \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\";
+    export const AccountMigrationScheduledEvent = \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\";
+    export const AccountMigrationValidatedEvent = \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\";
+    export const BalanceRetrievedMigrationEvent = \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\";
+}
+
+export type Record = AccountMigrationEvent;
 
 export interface AccountMigrationEvent {
     event: NamespacedAccountMigrationCancelledEvent | NamespacedAccountMigrationCompletedEvent | NamespacedAccountMigrationRollBackInitiatedEvent | NamespacedAccountMigrationRolledBackEvent | NamespacedAccountMigrationScheduledEvent | NamespacedAccountMigrationValidatedEvent | NamespacedBalanceRetrievedMigrationEvent;
@@ -105,6 +115,12 @@ export interface EventMetadata {
 
 export interface NamespacedAccountMigrationCancelledEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": AccountMigrationCancelledEvent;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
 }
 
 export interface AccountMigrationCompletedEvent {
@@ -129,6 +145,12 @@ export interface AccountMigrationCompletedEvent {
 
 export interface NamespacedAccountMigrationCompletedEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": AccountMigrationCompletedEvent;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
 }
 
 export interface AccountMigrationRollBackInitiatedEvent {
@@ -153,6 +175,12 @@ export interface AccountMigrationRollBackInitiatedEvent {
 
 export interface NamespacedAccountMigrationRollBackInitiatedEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": AccountMigrationRollBackInitiatedEvent;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
 }
 
 export interface AccountMigrationRolledBackEvent {
@@ -177,6 +205,12 @@ export interface AccountMigrationRolledBackEvent {
 
 export interface NamespacedAccountMigrationRolledBackEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": AccountMigrationRolledBackEvent;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
 }
 
 export interface AccountMigrationScheduledEvent {
@@ -209,6 +243,12 @@ export interface AccountMigrationScheduledEvent {
 
 export interface NamespacedAccountMigrationScheduledEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": AccountMigrationScheduledEvent;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
 }
 
 export interface AccountMigrationValidatedEvent {
@@ -233,6 +273,12 @@ export interface AccountMigrationValidatedEvent {
 
 export interface NamespacedAccountMigrationValidatedEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": AccountMigrationValidatedEvent;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
 }
 
 export interface BalanceRetrievedMigrationEvent {
@@ -261,6 +307,12 @@ export interface BalanceRetrievedMigrationEvent {
 
 export interface NamespacedBalanceRetrievedMigrationEvent {
     \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": BalanceRetrievedMigrationEvent;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
 }"
 `;
 
@@ -318,7 +370,17 @@ export interface EmailAddress {
 `;
 
 exports[`Cli Should convert files with logical types 2`] = `
-"export type Record = AccountMigrationEvent;
+"export namespace Names {
+    export const AccountMigrationCancelledEvent = \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\";
+    export const AccountMigrationCompletedEvent = \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\";
+    export const AccountMigrationRollBackInitiatedEvent = \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\";
+    export const AccountMigrationRolledBackEvent = \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\";
+    export const AccountMigrationScheduledEvent = \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\";
+    export const AccountMigrationValidatedEvent = \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\";
+    export const BalanceRetrievedMigrationEvent = \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\";
+}
+
+export type Record = AccountMigrationEvent;
 
 export interface AccountMigrationEvent {
     event: NamespacedAccountMigrationCancelledEvent | NamespacedAccountMigrationCompletedEvent | NamespacedAccountMigrationRollBackInitiatedEvent | NamespacedAccountMigrationRolledBackEvent | NamespacedAccountMigrationScheduledEvent | NamespacedAccountMigrationValidatedEvent | NamespacedBalanceRetrievedMigrationEvent;
@@ -369,6 +431,12 @@ export interface EventMetadata {
 
 export interface NamespacedAccountMigrationCancelledEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": AccountMigrationCancelledEvent;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
 }
 
 export interface AccountMigrationCompletedEvent {
@@ -393,6 +461,12 @@ export interface AccountMigrationCompletedEvent {
 
 export interface NamespacedAccountMigrationCompletedEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": AccountMigrationCompletedEvent;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
 }
 
 export interface AccountMigrationRollBackInitiatedEvent {
@@ -417,6 +491,12 @@ export interface AccountMigrationRollBackInitiatedEvent {
 
 export interface NamespacedAccountMigrationRollBackInitiatedEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": AccountMigrationRollBackInitiatedEvent;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
 }
 
 export interface AccountMigrationRolledBackEvent {
@@ -441,6 +521,12 @@ export interface AccountMigrationRolledBackEvent {
 
 export interface NamespacedAccountMigrationRolledBackEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": AccountMigrationRolledBackEvent;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
 }
 
 export interface AccountMigrationScheduledEvent {
@@ -473,6 +559,12 @@ export interface AccountMigrationScheduledEvent {
 
 export interface NamespacedAccountMigrationScheduledEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": AccountMigrationScheduledEvent;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
 }
 
 export interface AccountMigrationValidatedEvent {
@@ -497,6 +589,12 @@ export interface AccountMigrationValidatedEvent {
 
 export interface NamespacedAccountMigrationValidatedEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": AccountMigrationValidatedEvent;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
 }
 
 export interface BalanceRetrievedMigrationEvent {
@@ -525,11 +623,27 @@ export interface BalanceRetrievedMigrationEvent {
 
 export interface NamespacedBalanceRetrievedMigrationEvent {
     \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": BalanceRetrievedMigrationEvent;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
 }"
 `;
 
 exports[`Cli Should convert files with logical types and imports 1`] = `
 "import { Decimal } from 'decimal.js'
+
+export namespace Names {
+    export const AccountMigrationCancelledEvent = \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\";
+    export const AccountMigrationCompletedEvent = \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\";
+    export const AccountMigrationRollBackInitiatedEvent = \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\";
+    export const AccountMigrationRolledBackEvent = \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\";
+    export const AccountMigrationScheduledEvent = \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\";
+    export const AccountMigrationValidatedEvent = \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\";
+    export const BalanceRetrievedMigrationEvent = \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\";
+}
 
 export type Record = AccountMigrationEvent;
 
@@ -582,6 +696,12 @@ export interface EventMetadata {
 
 export interface NamespacedAccountMigrationCancelledEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": AccountMigrationCancelledEvent;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
 }
 
 export interface AccountMigrationCompletedEvent {
@@ -606,6 +726,12 @@ export interface AccountMigrationCompletedEvent {
 
 export interface NamespacedAccountMigrationCompletedEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": AccountMigrationCompletedEvent;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
 }
 
 export interface AccountMigrationRollBackInitiatedEvent {
@@ -630,6 +756,12 @@ export interface AccountMigrationRollBackInitiatedEvent {
 
 export interface NamespacedAccountMigrationRollBackInitiatedEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": AccountMigrationRollBackInitiatedEvent;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
 }
 
 export interface AccountMigrationRolledBackEvent {
@@ -654,6 +786,12 @@ export interface AccountMigrationRolledBackEvent {
 
 export interface NamespacedAccountMigrationRolledBackEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": AccountMigrationRolledBackEvent;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
 }
 
 export interface AccountMigrationScheduledEvent {
@@ -686,6 +824,12 @@ export interface AccountMigrationScheduledEvent {
 
 export interface NamespacedAccountMigrationScheduledEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": AccountMigrationScheduledEvent;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
 }
 
 export interface AccountMigrationValidatedEvent {
@@ -710,6 +854,12 @@ export interface AccountMigrationValidatedEvent {
 
 export interface NamespacedAccountMigrationValidatedEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": AccountMigrationValidatedEvent;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
 }
 
 export interface BalanceRetrievedMigrationEvent {
@@ -738,6 +888,12 @@ export interface BalanceRetrievedMigrationEvent {
 
 export interface NamespacedBalanceRetrievedMigrationEvent {
     \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": BalanceRetrievedMigrationEvent;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
 }"
 `;
 
@@ -795,7 +951,17 @@ export interface EmailAddress {
 `;
 
 exports[`Cli Should convert multiple files 2`] = `
-"export type Record = AccountMigrationEvent;
+"export namespace Names {
+    export const AccountMigrationCancelledEvent = \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\";
+    export const AccountMigrationCompletedEvent = \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\";
+    export const AccountMigrationRollBackInitiatedEvent = \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\";
+    export const AccountMigrationRolledBackEvent = \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\";
+    export const AccountMigrationScheduledEvent = \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\";
+    export const AccountMigrationValidatedEvent = \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\";
+    export const BalanceRetrievedMigrationEvent = \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\";
+}
+
+export type Record = AccountMigrationEvent;
 
 export interface AccountMigrationEvent {
     event: NamespacedAccountMigrationCancelledEvent | NamespacedAccountMigrationCompletedEvent | NamespacedAccountMigrationRollBackInitiatedEvent | NamespacedAccountMigrationRolledBackEvent | NamespacedAccountMigrationScheduledEvent | NamespacedAccountMigrationValidatedEvent | NamespacedBalanceRetrievedMigrationEvent;
@@ -846,6 +1012,12 @@ export interface EventMetadata {
 
 export interface NamespacedAccountMigrationCancelledEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": AccountMigrationCancelledEvent;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
 }
 
 export interface AccountMigrationCompletedEvent {
@@ -870,6 +1042,12 @@ export interface AccountMigrationCompletedEvent {
 
 export interface NamespacedAccountMigrationCompletedEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": AccountMigrationCompletedEvent;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
 }
 
 export interface AccountMigrationRollBackInitiatedEvent {
@@ -894,6 +1072,12 @@ export interface AccountMigrationRollBackInitiatedEvent {
 
 export interface NamespacedAccountMigrationRollBackInitiatedEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": AccountMigrationRollBackInitiatedEvent;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
 }
 
 export interface AccountMigrationRolledBackEvent {
@@ -918,6 +1102,12 @@ export interface AccountMigrationRolledBackEvent {
 
 export interface NamespacedAccountMigrationRolledBackEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": AccountMigrationRolledBackEvent;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
 }
 
 export interface AccountMigrationScheduledEvent {
@@ -950,6 +1140,12 @@ export interface AccountMigrationScheduledEvent {
 
 export interface NamespacedAccountMigrationScheduledEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": AccountMigrationScheduledEvent;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
 }
 
 export interface AccountMigrationValidatedEvent {
@@ -974,6 +1170,12 @@ export interface AccountMigrationValidatedEvent {
 
 export interface NamespacedAccountMigrationValidatedEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": AccountMigrationValidatedEvent;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
 }
 
 export interface BalanceRetrievedMigrationEvent {
@@ -1002,6 +1204,12 @@ export interface BalanceRetrievedMigrationEvent {
 
 export interface NamespacedBalanceRetrievedMigrationEvent {
     \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": BalanceRetrievedMigrationEvent;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
 }"
 `;
 

--- a/packages/avro-ts/README.md
+++ b/packages/avro-ts/README.md
@@ -49,9 +49,9 @@ This converter currently supports
 
 ## Union types helpers.
 
-When complex union types are defined, the output will include a namespace named `Names` by default, containing the namespaced address of properties.
+When complex union types are defined, the output will include a namespace (named `Names` by default), containing the namespaced address of properties.
 
-This allows using as such:
+This allows usecases as such:
 
 ```typescript
 import { Names, WeatherEvent } from './my-type';

--- a/packages/avro-ts/README.md
+++ b/packages/avro-ts/README.md
@@ -47,6 +47,20 @@ This converter currently supports
 - Array
 - Root-level union types
 
+## Union types helpers.
+
+When complex union types are defined, the output will include a namespace named `Names` by default, containing the namespaced address of properties.
+
+This allows using as such:
+
+```typescript
+import { Names, WeatherEvent } from './my-type';
+const event: WeatherEvent = {};
+event[Names.RainEvent];
+```
+
+The union members uses [`never`](https://www.typescriptlang.org/docs/handbook/basic-types.html#never) to prevent erroneously creating/accessing a union member with mutiple keys.
+
 ## Running the tests
 
 Then you can run the tests with:

--- a/packages/avro-ts/README.md
+++ b/packages/avro-ts/README.md
@@ -27,6 +27,7 @@ const ts = avroTs(avro, {
     },
   },
   recordAlias: 'Record',
+  namesAlias: 'Names',
   namespacedPrefix: 'Namespaced',
 });
 

--- a/packages/avro-ts/package.json
+++ b/packages/avro-ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ovotech/avro-ts",
   "description": "Convert avro schemas into typescript interfaces",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "main": "dist/index.js",
   "source": "src/index.ts",
   "types": "dist/index.d.ts",

--- a/packages/avro-ts/package.json
+++ b/packages/avro-ts/package.json
@@ -9,7 +9,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "test-js": "jest --runInBand",
-    "test-ts": "tsc test/integration.ts --strict --noEmit",
+    "test-ts": "tsc test/integration.ts --strict --noEmit && ! tsc test/integration-should-fail.ts --strict --noEmit",
     "test": "yarn test-js && yarn test-ts",
     "lint-prettier": "prettier --list-different {src,test}/**/*.ts",
     "lint-tslint": "tslint --config tslint.json '{src,test}/**/*.ts'",

--- a/packages/avro-ts/src/index.ts
+++ b/packages/avro-ts/src/index.ts
@@ -140,7 +140,7 @@ const convertRecord: Convert<schema.RecordType> = (context, type) => {
             ts.createPropertySignature(
               undefined,
               ts.createStringLiteral(`${currentNamespace}.${name}`),
-              undefined,
+              ts.createToken(ts.SyntaxKind.QuestionToken),
               ts.createKeywordTypeNode(ts.SyntaxKind.NeverKeyword),
               undefined,
             ),

--- a/packages/avro-ts/test/__snapshots__/index.spec.ts.snap
+++ b/packages/avro-ts/test/__snapshots__/index.spec.ts.snap
@@ -35,6 +35,7 @@ export interface Config {
 
 export interface NamespacedConfig {
     \\"com.ovoenergy.kafka.common.event.Config\\": Config;
+    \\"com.ovoenergy.kafka.common.event.EventMetadata\\": never;
 }
 
 export interface ConfigExtended {
@@ -44,6 +45,7 @@ export interface ConfigExtended {
 
 export interface NamespacedConfigExtended {
     \\"com.ovoenergy.kafka.common.event.ConfigExtended\\": ConfigExtended;
+    \\"com.ovoenergy.kafka.common.event.EventMetadata\\": never;
 }
 
 export interface BalanceAdjustmentRequest {
@@ -75,6 +77,7 @@ export interface BalanceAdjustmentRequest {
 
 export interface NamespacedBalanceAdjustmentRequest {
     \\"uk.co.boostpower.support.kafka.messages.BalanceAdjustmentRequest\\": BalanceAdjustmentRequest;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceAdjustment\\": never;
 }
 
 export interface BalanceAdjustmentResponse {
@@ -94,6 +97,7 @@ export interface BalanceAdjustmentResponse {
 
 export interface NamespacedBalanceAdjustmentResponse {
     \\"uk.co.boostpower.support.kafka.messages.BalanceAdjustmentResponse\\": BalanceAdjustmentResponse;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceAdjustment\\": never;
 }"
 `;
 
@@ -207,6 +211,7 @@ export interface EventMetadata {
 
 export interface NamespacedAccountMigrationCancelledEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": AccountMigrationCancelledEvent;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationEvent\\": never;
 }
 
 export interface AccountMigrationCompletedEvent {
@@ -231,6 +236,7 @@ export interface AccountMigrationCompletedEvent {
 
 export interface NamespacedAccountMigrationCompletedEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": AccountMigrationCompletedEvent;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationEvent\\": never;
 }
 
 export interface AccountMigrationRollBackInitiatedEvent {
@@ -255,6 +261,7 @@ export interface AccountMigrationRollBackInitiatedEvent {
 
 export interface NamespacedAccountMigrationRollBackInitiatedEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": AccountMigrationRollBackInitiatedEvent;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationEvent\\": never;
 }
 
 export interface AccountMigrationRolledBackEvent {
@@ -279,6 +286,7 @@ export interface AccountMigrationRolledBackEvent {
 
 export interface NamespacedAccountMigrationRolledBackEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": AccountMigrationRolledBackEvent;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationEvent\\": never;
 }
 
 export interface AccountMigrationScheduledEvent {
@@ -311,6 +319,7 @@ export interface AccountMigrationScheduledEvent {
 
 export interface NamespacedAccountMigrationScheduledEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": AccountMigrationScheduledEvent;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationEvent\\": never;
 }
 
 export interface AccountMigrationValidatedEvent {
@@ -335,6 +344,7 @@ export interface AccountMigrationValidatedEvent {
 
 export interface NamespacedAccountMigrationValidatedEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": AccountMigrationValidatedEvent;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationEvent\\": never;
 }
 
 export interface BalanceRetrievedMigrationEvent {
@@ -363,6 +373,7 @@ export interface BalanceRetrievedMigrationEvent {
 
 export interface NamespacedBalanceRetrievedMigrationEvent {
     \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": BalanceRetrievedMigrationEvent;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationEvent\\": never;
 }"
 `;
 
@@ -596,6 +607,7 @@ export interface EventMetadata {
 
 export interface NamespacedCancelled {
     \\"com.example.avro.Cancelled\\": Cancelled;
+    \\"com.example.avro.Creation\\": never;
 }
 
 export interface Creation {
@@ -605,6 +617,7 @@ export interface Creation {
 
 export interface NamespacedCreation {
     \\"com.example.avro.Creation\\": Creation;
+    \\"com.example.avro.Cancelled\\": never;
 }"
 `;
 
@@ -761,6 +774,7 @@ export interface EventMetadata {
 
 export interface NSCancelled {
     \\"com.example.avro.Cancelled\\": Cancelled;
+    \\"com.example.avro.Creation\\": never;
 }
 
 export interface Creation {
@@ -770,5 +784,6 @@ export interface Creation {
 
 export interface NSCreation {
     \\"com.example.avro.Creation\\": Creation;
+    \\"com.example.avro.Cancelled\\": never;
 }"
 `;

--- a/packages/avro-ts/test/__snapshots__/index.spec.ts.snap
+++ b/packages/avro-ts/test/__snapshots__/index.spec.ts.snap
@@ -37,7 +37,7 @@ export interface Config {
 
 export interface NamespacedConfig {
     \\"com.ovoenergy.kafka.common.event.Config\\": Config;
-    \\"com.ovoenergy.kafka.common.event.ConfigExtended\\": never;
+    \\"com.ovoenergy.kafka.common.event.ConfigExtended\\"?: never;
 }
 
 export interface ConfigExtended {
@@ -47,7 +47,7 @@ export interface ConfigExtended {
 
 export interface NamespacedConfigExtended {
     \\"com.ovoenergy.kafka.common.event.ConfigExtended\\": ConfigExtended;
-    \\"com.ovoenergy.kafka.common.event.Config\\": never;
+    \\"com.ovoenergy.kafka.common.event.Config\\"?: never;
 }
 
 export interface BalanceAdjustmentRequest {
@@ -79,7 +79,7 @@ export interface BalanceAdjustmentRequest {
 
 export interface NamespacedBalanceAdjustmentRequest {
     \\"uk.co.boostpower.support.kafka.messages.BalanceAdjustmentRequest\\": BalanceAdjustmentRequest;
-    \\"uk.co.boostpower.support.kafka.messages.BalanceAdjustmentResponse\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceAdjustmentResponse\\"?: never;
 }
 
 export interface BalanceAdjustmentResponse {
@@ -99,7 +99,7 @@ export interface BalanceAdjustmentResponse {
 
 export interface NamespacedBalanceAdjustmentResponse {
     \\"uk.co.boostpower.support.kafka.messages.BalanceAdjustmentResponse\\": BalanceAdjustmentResponse;
-    \\"uk.co.boostpower.support.kafka.messages.BalanceAdjustmentRequest\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceAdjustmentRequest\\"?: never;
 }"
 `;
 
@@ -214,12 +214,12 @@ export interface EventMetadata {
 
 export interface NamespacedAccountMigrationCancelledEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": AccountMigrationCancelledEvent;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\"?: never;
 }
 
 export interface AccountMigrationCompletedEvent {
@@ -244,12 +244,12 @@ export interface AccountMigrationCompletedEvent {
 
 export interface NamespacedAccountMigrationCompletedEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": AccountMigrationCompletedEvent;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\"?: never;
 }
 
 export interface AccountMigrationRollBackInitiatedEvent {
@@ -274,12 +274,12 @@ export interface AccountMigrationRollBackInitiatedEvent {
 
 export interface NamespacedAccountMigrationRollBackInitiatedEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": AccountMigrationRollBackInitiatedEvent;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\"?: never;
 }
 
 export interface AccountMigrationRolledBackEvent {
@@ -304,12 +304,12 @@ export interface AccountMigrationRolledBackEvent {
 
 export interface NamespacedAccountMigrationRolledBackEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": AccountMigrationRolledBackEvent;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\"?: never;
 }
 
 export interface AccountMigrationScheduledEvent {
@@ -342,12 +342,12 @@ export interface AccountMigrationScheduledEvent {
 
 export interface NamespacedAccountMigrationScheduledEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": AccountMigrationScheduledEvent;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\"?: never;
 }
 
 export interface AccountMigrationValidatedEvent {
@@ -372,12 +372,12 @@ export interface AccountMigrationValidatedEvent {
 
 export interface NamespacedAccountMigrationValidatedEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": AccountMigrationValidatedEvent;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\"?: never;
 }
 
 export interface BalanceRetrievedMigrationEvent {
@@ -406,12 +406,12 @@ export interface BalanceRetrievedMigrationEvent {
 
 export interface NamespacedBalanceRetrievedMigrationEvent {
     \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": BalanceRetrievedMigrationEvent;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\"?: never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\"?: never;
 }"
 `;
 
@@ -616,7 +616,7 @@ export interface EventMetadata {
 
 export interface NamespacedCancelled {
     \\"com.example.avro.Cancelled\\": Cancelled;
-    \\"com.example.avro.Creation\\": never;
+    \\"com.example.avro.Creation\\"?: never;
 }
 
 export interface Creation {
@@ -626,7 +626,7 @@ export interface Creation {
 
 export interface NamespacedCreation {
     \\"com.example.avro.Creation\\": Creation;
-    \\"com.example.avro.Cancelled\\": never;
+    \\"com.example.avro.Cancelled\\"?: never;
 }"
 `;
 
@@ -774,7 +774,7 @@ export interface EventMetadata {
 
 export interface NSCancelled {
     \\"com.example.avro.Cancelled\\": Cancelled;
-    \\"com.example.avro.Creation\\": never;
+    \\"com.example.avro.Creation\\"?: never;
 }
 
 export interface Creation {
@@ -784,6 +784,6 @@ export interface Creation {
 
 export interface NSCreation {
     \\"com.example.avro.Creation\\": Creation;
-    \\"com.example.avro.Cancelled\\": never;
+    \\"com.example.avro.Cancelled\\"?: never;
 }"
 `;

--- a/packages/avro-ts/test/__snapshots__/index.spec.ts.snap
+++ b/packages/avro-ts/test/__snapshots__/index.spec.ts.snap
@@ -2,8 +2,10 @@
 
 exports[`Avro ts test Should convert BalanceAdjustment.avsc successfully 1`] = `
 "export namespace Names {
-    export const BalanceAdjustment = \\"uk.co.boostpower.support.kafka.messages.BalanceAdjustment\\";
-    export const EventMetadata = \\"com.ovoenergy.kafka.common.event.EventMetadata\\";
+    export const Config = \\"com.ovoenergy.kafka.common.event.Config\\";
+    export const ConfigExtended = \\"com.ovoenergy.kafka.common.event.ConfigExtended\\";
+    export const BalanceAdjustmentRequest = \\"uk.co.boostpower.support.kafka.messages.BalanceAdjustmentRequest\\";
+    export const BalanceAdjustmentResponse = \\"uk.co.boostpower.support.kafka.messages.BalanceAdjustmentResponse\\";
 }
 
 export type Record = BalanceAdjustment;
@@ -35,7 +37,7 @@ export interface Config {
 
 export interface NamespacedConfig {
     \\"com.ovoenergy.kafka.common.event.Config\\": Config;
-    \\"com.ovoenergy.kafka.common.event.EventMetadata\\": never;
+    \\"com.ovoenergy.kafka.common.event.ConfigExtended\\": never;
 }
 
 export interface ConfigExtended {
@@ -45,7 +47,7 @@ export interface ConfigExtended {
 
 export interface NamespacedConfigExtended {
     \\"com.ovoenergy.kafka.common.event.ConfigExtended\\": ConfigExtended;
-    \\"com.ovoenergy.kafka.common.event.EventMetadata\\": never;
+    \\"com.ovoenergy.kafka.common.event.Config\\": never;
 }
 
 export interface BalanceAdjustmentRequest {
@@ -77,7 +79,7 @@ export interface BalanceAdjustmentRequest {
 
 export interface NamespacedBalanceAdjustmentRequest {
     \\"uk.co.boostpower.support.kafka.messages.BalanceAdjustmentRequest\\": BalanceAdjustmentRequest;
-    \\"uk.co.boostpower.support.kafka.messages.BalanceAdjustment\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceAdjustmentResponse\\": never;
 }
 
 export interface BalanceAdjustmentResponse {
@@ -97,16 +99,12 @@ export interface BalanceAdjustmentResponse {
 
 export interface NamespacedBalanceAdjustmentResponse {
     \\"uk.co.boostpower.support.kafka.messages.BalanceAdjustmentResponse\\": BalanceAdjustmentResponse;
-    \\"uk.co.boostpower.support.kafka.messages.BalanceAdjustment\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceAdjustmentRequest\\": never;
 }"
 `;
 
 exports[`Avro ts test Should convert ComplexRecord.avsc successfully 1`] = `
-"export namespace Names {
-    export const User = \\"com.example.avro.User\\";
-}
-
-export type Record = User;
+"export type Record = User;
 
 export interface User {
     /**
@@ -160,8 +158,13 @@ export interface EmailAddress {
 
 exports[`Avro ts test Should convert ComplexUnionLogicalTypes.avsc successfully 1`] = `
 "export namespace Names {
-    export const AccountMigrationEvent = \\"uk.co.boostpower.support.kafka.messages.AccountMigrationEvent\\";
-    export const EventMetadata = \\"com.ovoenergy.kafka.common.event.EventMetadata\\";
+    export const AccountMigrationCancelledEvent = \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\";
+    export const AccountMigrationCompletedEvent = \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\";
+    export const AccountMigrationRollBackInitiatedEvent = \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\";
+    export const AccountMigrationRolledBackEvent = \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\";
+    export const AccountMigrationScheduledEvent = \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\";
+    export const AccountMigrationValidatedEvent = \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\";
+    export const BalanceRetrievedMigrationEvent = \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\";
 }
 
 export type Record = AccountMigrationEvent;
@@ -211,7 +214,12 @@ export interface EventMetadata {
 
 export interface NamespacedAccountMigrationCancelledEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": AccountMigrationCancelledEvent;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
 }
 
 export interface AccountMigrationCompletedEvent {
@@ -236,7 +244,12 @@ export interface AccountMigrationCompletedEvent {
 
 export interface NamespacedAccountMigrationCompletedEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": AccountMigrationCompletedEvent;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
 }
 
 export interface AccountMigrationRollBackInitiatedEvent {
@@ -261,7 +274,12 @@ export interface AccountMigrationRollBackInitiatedEvent {
 
 export interface NamespacedAccountMigrationRollBackInitiatedEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": AccountMigrationRollBackInitiatedEvent;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
 }
 
 export interface AccountMigrationRolledBackEvent {
@@ -286,7 +304,12 @@ export interface AccountMigrationRolledBackEvent {
 
 export interface NamespacedAccountMigrationRolledBackEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": AccountMigrationRolledBackEvent;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
 }
 
 export interface AccountMigrationScheduledEvent {
@@ -319,7 +342,12 @@ export interface AccountMigrationScheduledEvent {
 
 export interface NamespacedAccountMigrationScheduledEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": AccountMigrationScheduledEvent;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
 }
 
 export interface AccountMigrationValidatedEvent {
@@ -344,7 +372,12 @@ export interface AccountMigrationValidatedEvent {
 
 export interface NamespacedAccountMigrationValidatedEvent {
     \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": AccountMigrationValidatedEvent;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": never;
 }
 
 export interface BalanceRetrievedMigrationEvent {
@@ -373,16 +406,17 @@ export interface BalanceRetrievedMigrationEvent {
 
 export interface NamespacedBalanceRetrievedMigrationEvent {
     \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": BalanceRetrievedMigrationEvent;
-    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": never;
+    \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": never;
 }"
 `;
 
 exports[`Avro ts test Should convert RecordWithEnum.avsc successfully 1`] = `
-"export namespace Names {
-    export const User = \\"com.example.avro.User\\";
-}
-
-export type Record = User;
+"export type Record = User;
 
 export interface User {
     /**
@@ -409,11 +443,7 @@ export interface User {
 `;
 
 exports[`Avro ts test Should convert RecordWithInterface.avsc successfully 1`] = `
-"export namespace Names {
-    export const User = \\"com.example.avro.User\\";
-}
-
-export type Record = User;
+"export type Record = User;
 
 export interface User {
     /**
@@ -455,11 +485,7 @@ export interface EmailAddress {
 `;
 
 exports[`Avro ts test Should convert RecordWithLogicalTypes.avsc successfully 1`] = `
-"export namespace Names {
-    export const Event = \\"com.example.avro.Event\\";
-}
-
-export type Record = Event;
+"export type Record = Event;
 
 export interface Event {
     /**
@@ -475,10 +501,6 @@ export interface Event {
 
 exports[`Avro ts test Should convert RecordWithLogicalTypesImport.avsc successfully 1`] = `
 "import { Decimal } from 'my-library'
-
-export namespace Names {
-    export const Event = \\"com.example.avro.Event\\";
-}
 
 export type Record = Event;
 
@@ -499,11 +521,7 @@ export interface Event {
 `;
 
 exports[`Avro ts test Should convert RecordWithMap.avsc successfully 1`] = `
-"export namespace Names {
-    export const User = \\"com.example.avro.User\\";
-}
-
-export type Record = User;
+"export type Record = User;
 
 export interface User {
     /**
@@ -533,11 +551,7 @@ export interface Foo {
 `;
 
 exports[`Avro ts test Should convert RecordWithUnion.avsc successfully 1`] = `
-"export namespace Names {
-    export const User = \\"com.example.avro.User\\";
-}
-
-export type Record = User;
+"export type Record = User;
 
 export interface User {
     /**
@@ -561,11 +575,7 @@ export interface User {
 `;
 
 exports[`Avro ts test Should convert SimpleRecord.avsc successfully 1`] = `
-"export namespace Names {
-    export const User = \\"com.example.avro.User\\";
-}
-
-export type Record = User;
+"export type Record = User;
 
 export interface User {
     /**
@@ -591,7 +601,6 @@ exports[`Avro ts test Should convert TopLevelUnion.avsc successfully 1`] = `
 "export namespace Names {
     export const Cancelled = \\"com.example.avro.Cancelled\\";
     export const Creation = \\"com.example.avro.Creation\\";
-    export const EventMetadata = \\"com.example.avro.event.EventMetadata\\";
 }
 
 export type Record = NamespacedCancelled | NamespacedCreation;
@@ -622,11 +631,7 @@ export interface NamespacedCreation {
 `;
 
 exports[`Avro ts test Should convert TradeCollection.avsc successfully 1`] = `
-"export namespace Names {
-    export const TradeCollection = \\"com.example.avro.TradeCollection\\";
-}
-
-export type Record = TradeCollection;
+"export type Record = TradeCollection;
 
 export interface TradeCollection {
     producerId: string;
@@ -647,11 +652,7 @@ export interface Trade {
 `;
 
 exports[`Avro ts test Should convert User.avsc successfully 1`] = `
-"export namespace Names {
-    export const User = \\"com.example.avro.User\\";
-}
-
-export type Record = User;
+"export type Record = User;
 
 export interface User {
     /**
@@ -758,7 +759,6 @@ exports[`Avro ts test supports providing different names for record and namespac
 "export namespace Names {
     export const Cancelled = \\"com.example.avro.Cancelled\\";
     export const Creation = \\"com.example.avro.Creation\\";
-    export const EventMetadata = \\"com.example.avro.event.EventMetadata\\";
 }
 
 export type Event = NSCancelled | NSCreation;

--- a/packages/avro-ts/test/__snapshots__/index.spec.ts.snap
+++ b/packages/avro-ts/test/__snapshots__/index.spec.ts.snap
@@ -1,7 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Avro ts test Should convert BalanceAdjustment.avsc successfully 1`] = `
-"export type Record = BalanceAdjustment;
+"export namespace Names {
+    export const BalanceAdjustment = \\"uk.co.boostpower.support.kafka.messages.BalanceAdjustment\\";
+    export const EventMetadata = \\"com.ovoenergy.kafka.common.event.EventMetadata\\";
+}
+
+export type Record = BalanceAdjustment;
 
 export interface BalanceAdjustment {
     metadata: EventMetadata;
@@ -93,7 +98,11 @@ export interface NamespacedBalanceAdjustmentResponse {
 `;
 
 exports[`Avro ts test Should convert ComplexRecord.avsc successfully 1`] = `
-"export type Record = User;
+"export namespace Names {
+    export const User = \\"com.example.avro.User\\";
+}
+
+export type Record = User;
 
 export interface User {
     /**
@@ -146,7 +155,12 @@ export interface EmailAddress {
 `;
 
 exports[`Avro ts test Should convert ComplexUnionLogicalTypes.avsc successfully 1`] = `
-"export type Record = AccountMigrationEvent;
+"export namespace Names {
+    export const AccountMigrationEvent = \\"uk.co.boostpower.support.kafka.messages.AccountMigrationEvent\\";
+    export const EventMetadata = \\"com.ovoenergy.kafka.common.event.EventMetadata\\";
+}
+
+export type Record = AccountMigrationEvent;
 
 export interface AccountMigrationEvent {
     event: NamespacedAccountMigrationCancelledEvent | NamespacedAccountMigrationCompletedEvent | NamespacedAccountMigrationRollBackInitiatedEvent | NamespacedAccountMigrationRolledBackEvent | NamespacedAccountMigrationScheduledEvent | NamespacedAccountMigrationValidatedEvent | NamespacedBalanceRetrievedMigrationEvent;
@@ -353,7 +367,11 @@ export interface NamespacedBalanceRetrievedMigrationEvent {
 `;
 
 exports[`Avro ts test Should convert RecordWithEnum.avsc successfully 1`] = `
-"export type Record = User;
+"export namespace Names {
+    export const User = \\"com.example.avro.User\\";
+}
+
+export type Record = User;
 
 export interface User {
     /**
@@ -380,7 +398,11 @@ export interface User {
 `;
 
 exports[`Avro ts test Should convert RecordWithInterface.avsc successfully 1`] = `
-"export type Record = User;
+"export namespace Names {
+    export const User = \\"com.example.avro.User\\";
+}
+
+export type Record = User;
 
 export interface User {
     /**
@@ -422,7 +444,11 @@ export interface EmailAddress {
 `;
 
 exports[`Avro ts test Should convert RecordWithLogicalTypes.avsc successfully 1`] = `
-"export type Record = Event;
+"export namespace Names {
+    export const Event = \\"com.example.avro.Event\\";
+}
+
+export type Record = Event;
 
 export interface Event {
     /**
@@ -438,6 +464,10 @@ export interface Event {
 
 exports[`Avro ts test Should convert RecordWithLogicalTypesImport.avsc successfully 1`] = `
 "import { Decimal } from 'my-library'
+
+export namespace Names {
+    export const Event = \\"com.example.avro.Event\\";
+}
 
 export type Record = Event;
 
@@ -458,7 +488,11 @@ export interface Event {
 `;
 
 exports[`Avro ts test Should convert RecordWithMap.avsc successfully 1`] = `
-"export type Record = User;
+"export namespace Names {
+    export const User = \\"com.example.avro.User\\";
+}
+
+export type Record = User;
 
 export interface User {
     /**
@@ -488,7 +522,11 @@ export interface Foo {
 `;
 
 exports[`Avro ts test Should convert RecordWithUnion.avsc successfully 1`] = `
-"export type Record = User;
+"export namespace Names {
+    export const User = \\"com.example.avro.User\\";
+}
+
+export type Record = User;
 
 export interface User {
     /**
@@ -512,7 +550,11 @@ export interface User {
 `;
 
 exports[`Avro ts test Should convert SimpleRecord.avsc successfully 1`] = `
-"export type Record = User;
+"export namespace Names {
+    export const User = \\"com.example.avro.User\\";
+}
+
+export type Record = User;
 
 export interface User {
     /**
@@ -535,7 +577,13 @@ export interface User {
 `;
 
 exports[`Avro ts test Should convert TopLevelUnion.avsc successfully 1`] = `
-"export type Record = NamespacedCancelled | NamespacedCreation;
+"export namespace Names {
+    export const Cancelled = \\"com.example.avro.Cancelled\\";
+    export const Creation = \\"com.example.avro.Creation\\";
+    export const EventMetadata = \\"com.example.avro.event.EventMetadata\\";
+}
+
+export type Record = NamespacedCancelled | NamespacedCreation;
 
 export interface Cancelled {
     metadata: EventMetadata;
@@ -561,7 +609,11 @@ export interface NamespacedCreation {
 `;
 
 exports[`Avro ts test Should convert TradeCollection.avsc successfully 1`] = `
-"export type Record = TradeCollection;
+"export namespace Names {
+    export const TradeCollection = \\"com.example.avro.TradeCollection\\";
+}
+
+export type Record = TradeCollection;
 
 export interface TradeCollection {
     producerId: string;
@@ -582,7 +634,11 @@ export interface Trade {
 `;
 
 exports[`Avro ts test Should convert User.avsc successfully 1`] = `
-"export type Record = User;
+"export namespace Names {
+    export const User = \\"com.example.avro.User\\";
+}
+
+export type Record = User;
 
 export interface User {
     /**
@@ -686,7 +742,13 @@ export interface ToDoItem {
 `;
 
 exports[`Avro ts test supports providing different names for record and namespaced type 1`] = `
-"export type Event = NSCancelled | NSCreation;
+"export namespace Names {
+    export const Cancelled = \\"com.example.avro.Cancelled\\";
+    export const Creation = \\"com.example.avro.Creation\\";
+    export const EventMetadata = \\"com.example.avro.event.EventMetadata\\";
+}
+
+export type Event = NSCancelled | NSCreation;
 
 export interface Cancelled {
     metadata: EventMetadata;

--- a/packages/avro-ts/test/integration-should-fail.ts
+++ b/packages/avro-ts/test/integration-should-fail.ts
@@ -1,0 +1,25 @@
+/* Use this files to test that failures are happening
+   as they should
+ */
+import {
+  Names as AccountNames,
+  AccountMigrationEvent as ComplexUnionLogicalTypes,
+  NamespacedAccountMigrationCancelledEvent,
+} from './__generated__/ComplexUnionLogicalTypes.avsc';
+
+// @ts-ignore we don't need the real data for our test
+const complexUnionLogicalTypes: AccountMigrationEvent = {};
+
+function isAccountMigrationCancelled(
+  msg: ComplexUnionLogicalTypes,
+): msg is ComplexUnionLogicalTypes & { event: NamespacedAccountMigrationCancelledEvent } {
+  return !!msg.event[AccountNames.AccountMigrationCancelledEvent];
+}
+
+if (isAccountMigrationCancelled(complexUnionLogicalTypes)) {
+  // .wat does not exist
+  complexUnionLogicalTypes.event[AccountNames.AccountMigrationCancelledEvent].wat; // should fail
+  // Our type is AccountMigrationCancelled, not AccountMigrationScheduled
+  // even though AccountMigrationScheduled has a `scheduledAt` property.
+  complexUnionLogicalTypes.event[AccountNames.AccountMigrationScheduledEvent].scheduledAt; // should fail
+}

--- a/packages/avro-ts/test/integration.ts
+++ b/packages/avro-ts/test/integration.ts
@@ -1,5 +1,8 @@
 import { User as ComplexRecord } from './__generated__/ComplexRecord.avsc';
-import { AccountMigrationEvent as ComplexUnionLogicalTypes } from './__generated__/ComplexUnionLogicalTypes.avsc';
+import {
+  Names as AccountNames,
+  AccountMigrationEvent as ComplexUnionLogicalTypes,
+} from './__generated__/ComplexUnionLogicalTypes.avsc';
 import { User as RecordWithEnum } from './__generated__/RecordWithEnum.avsc';
 import { User as RecordWithInterface } from './__generated__/RecordWithInterface.avsc';
 import { Event as RecordWithLogicalTypes } from './__generated__/RecordWithLogicalTypes.avsc';
@@ -25,7 +28,7 @@ const complexRecord: ComplexRecord = {
 
 const complexUnionLogicalTypes: ComplexUnionLogicalTypes = {
   event: {
-    'uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent': {
+    [AccountNames.AccountMigrationCancelledEvent]: {
       metadata: {
         eventId: '123',
         traceToken: '123',
@@ -166,4 +169,5 @@ console.log(
   simpleRecord,
   tradeCollection,
   user,
+  complexUnionLogicalTypes.event[AccountNames.AccountMigrationCancelledEvent],
 );


### PR DESCRIPTION
Hello! Diving straight into it:

# Bugfixes
- options for `avro-ts-cli` added by #37 were not handled properly

# New Features
## Export of "Names" 
Up until now, any caller of AvroTS with union type needed to duplicate the full keys to access the context of the namespaced record. This key is now exported for them.

## Give Typescript better hints for union types

Sprinkle a few `never` to help typescript understand which union type is accessed by key.

Before that change, the following would error:
```typescript
// let's assume this is valid initialisation, using the 
// ComplexUnionLogicalTypes test case
const event: AccountMigrationEvent = {}
event[Names.AccountMigrationEvent]
// Error:  Element implicitly has an 'any' type
// because type blah blah has no index signature
```

### Notes
The git history of this branch is a bit ugly. Let me know if you would like me to squash things a bit.