### PR TITLE
Avro-TS bugfixes

### DIFF
--- a/packages/avro-ts-cli/package.json
+++ b/packages/avro-ts-cli/package.json
@@ -19,7 +19,7 @@
     "avro-ts-cli": "ts-node src/cli.ts"
   },
   "dependencies": {
-    "@ovotech/avro-ts": "^3.0.0",
+    "@ovotech/avro-ts": "^3.1.0",
     "yargs": "^13.2.4"
   },
   "devDependencies": {

--- a/packages/avro-ts/package.json
+++ b/packages/avro-ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ovotech/avro-ts",
   "description": "Convert avro schemas into typescript interfaces",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "main": "dist/index.js",
   "source": "src/index.ts",
   "types": "dist/index.d.ts",

--- a/packages/avro-ts/test/__snapshots__/index.spec.ts.snap
+++ b/packages/avro-ts/test/__snapshots__/index.spec.ts.snap
@@ -415,6 +415,21 @@ export interface NamespacedBalanceRetrievedMigrationEvent {
 }"
 `;
 
+exports[`Avro ts test Should convert RecordWithDefault.avsc successfully 1`] = `
+"export type Record = RecordWithDefault;
+
+export interface RecordWithDefault {
+    pleaseNoNamespace?: null | NoNeedForNamespace;
+}
+
+export interface NoNeedForNamespace {
+    /**
+     * A fictitious id
+     */
+    id: string;
+}"
+`;
+
 exports[`Avro ts test Should convert RecordWithEnum.avsc successfully 1`] = `
 "export type Record = User;
 

--- a/packages/avro-ts/test/__snapshots__/index.spec.ts.snap
+++ b/packages/avro-ts/test/__snapshots__/index.spec.ts.snap
@@ -426,17 +426,11 @@ exports[`Avro ts test Should convert NestedRecordNamespace.avsc successfully 1`]
 export type Record = NestRecordEvent;
 
 export interface NestRecordEvent {
-    /**
-     * A personal projection in kWh.
-     */
     event: NamespacedLevel1Record | NamespacedLevel1Sibling;
 }
 
 export interface Level1Record {
     id: string;
-    /**
-     * The data backing this personal projection.
-     */
     child: NamespacedLevel2Record | NamespacedLevel2Sibling;
 }
 

--- a/packages/avro-ts/test/__snapshots__/index.spec.ts.snap
+++ b/packages/avro-ts/test/__snapshots__/index.spec.ts.snap
@@ -415,6 +415,64 @@ export interface NamespacedBalanceRetrievedMigrationEvent {
 }"
 `;
 
+exports[`Avro ts test Should convert NestedRecordNamespace.avsc successfully 1`] = `
+"export namespace Names {
+    export const Level1Record = \\"com.avro.example.Level1Record\\";
+    export const Level1Sibling = \\"com.avro.example.Level1Sibling\\";
+    export const Level2Record = \\"com.avro.example.Level2Record\\";
+    export const Level2Sibling = \\"com.avro.example.Level2Sibling\\";
+}
+
+export type Record = NestRecordEvent;
+
+export interface NestRecordEvent {
+    /**
+     * A personal projection in kWh.
+     */
+    event: NamespacedLevel1Record | NamespacedLevel1Sibling;
+}
+
+export interface Level1Record {
+    id: string;
+    /**
+     * The data backing this personal projection.
+     */
+    child: NamespacedLevel2Record | NamespacedLevel2Sibling;
+}
+
+export interface Level2Record {
+    id: string;
+}
+
+export interface NamespacedLevel2Record {
+    \\"com.avro.example.Level2Record\\": Level2Record;
+    \\"com.avro.example.Level2Sibling\\"?: never;
+}
+
+export interface Level2Sibling {
+    id: string;
+}
+
+export interface NamespacedLevel2Sibling {
+    \\"com.avro.example.Level2Sibling\\": Level2Sibling;
+    \\"com.avro.example.Level2Record\\"?: never;
+}
+
+export interface NamespacedLevel1Record {
+    \\"com.avro.example.Level1Record\\": Level1Record;
+    \\"com.avro.example.Level1Sibling\\"?: never;
+}
+
+export interface Level1Sibling {
+    id: string;
+}
+
+export interface NamespacedLevel1Sibling {
+    \\"com.avro.example.Level1Sibling\\": Level1Sibling;
+    \\"com.avro.example.Level1Record\\"?: never;
+}"
+`;
+
 exports[`Avro ts test Should convert RecordWithDefault.avsc successfully 1`] = `
 "export type Record = RecordWithDefault;
 

--- a/packages/avro-ts/test/avro/NestedRecordNamespace.avsc
+++ b/packages/avro-ts/test/avro/NestedRecordNamespace.avsc
@@ -37,8 +37,7 @@
                     }
                   ]
                 }
-              ],
-              "doc": "The data backing this personal projection."
+              ]
             }
           ]
         },
@@ -52,8 +51,7 @@
             }
           ]
         }
-      ],
-      "doc": "A personal projection in kWh."
+      ]
     }
   ]
 }

--- a/packages/avro-ts/test/avro/NestedRecordNamespace.avsc
+++ b/packages/avro-ts/test/avro/NestedRecordNamespace.avsc
@@ -1,0 +1,59 @@
+{
+  "type": "record",
+  "name": "NestRecordEvent",
+  "namespace": "com.avro.example",
+  "fields": [
+    {
+      "name": "event",
+      "type": [
+        {
+          "type": "record",
+          "name": "Level1Record",
+          "fields": [
+            {
+              "name": "id",
+              "type": "string"
+            },
+            {
+              "name": "child",
+              "type": [
+                {
+                  "type": "record",
+                  "name": "Level2Record",
+                  "fields": [
+                    {
+                      "name": "id",
+                      "type": "string"
+                    }
+                  ]
+                },
+                {
+                  "type": "record",
+                  "name": "Level2Sibling",
+                  "fields": [
+                    {
+                      "name": "id",
+                      "type": "string"
+                    }
+                  ]
+                }
+              ],
+              "doc": "The data backing this personal projection."
+            }
+          ]
+        },
+        {
+          "type": "record",
+          "name": "Level1Sibling",
+          "fields": [
+            {
+              "name": "id",
+              "type": "string"
+            }
+          ]
+        }
+      ],
+      "doc": "A personal projection in kWh."
+    }
+  ]
+}

--- a/packages/avro-ts/test/avro/RecordWithDefault.avsc
+++ b/packages/avro-ts/test/avro/RecordWithDefault.avsc
@@ -1,0 +1,25 @@
+{
+  "type": "record",
+  "name": "RecordWithDefault",
+  "namespace": "com.example.avro",
+  "fields": [
+    {
+      "name": "pleaseNoNamespace",
+      "type": [
+        "null",
+        {
+          "type": "record",
+          "name": "NoNeedForNamespace",
+          "fields": [
+            {
+              "name": "id",
+              "type": "string",
+              "doc": "A fictitious id"
+            }
+          ]
+        }
+      ],
+      "default": null
+    }
+  ]
+}


### PR DESCRIPTION
This fixes 2 bugs.

# Bug 1
Not all `record` type fields should be namespaced. I naively assumed they always should, if they are part of an array, but there could non `record` array members. This has been met with the `default` value of a record but I think it could happen with a union type `[null, "string", { type: "record",...}]`. I'm not entirely certain how to verify this latter assumption, any help would be warmly welcome :hugs: .

# Bug 2
The way the Union Registry was build was mixing up members of different unions if one was nested under another. This caused confusion with the `Namespaced*` type ending up forbidding more key than they should.