### PR TITLE
Add more logical types

### DIFF
--- a/packages/avro-logical-types/README.md
+++ b/packages/avro-logical-types/README.md
@@ -32,6 +32,18 @@ const deserializer = new AvroDeserializer('http://localhost:8081', {
 });
 ```
 
+### Available Types
+
+**DateType**: Dates serialised as epoch days (number of days since epoch), deserialised as ISO String
+
+**DateAsDateType**: Dates serialised as epoch days (number of days since epoch), deserialised as an instance of `Date`
+
+**TimestampType**: Dates serialised as timestamp, deserialised as ISO String
+
+**TimestampAsDateType**: Dates serialised as timestamp, deserialised as an instance of `Date`
+
+**DecimalType**: Decimal, up to 64bit (or 63 bit signed), serialised as bytes, deserialised as an instance of [decimal.js](https://npmjs.com/decimal.js)
+
 ## Running the tests
 
 You can run the tests with:

--- a/packages/avro-logical-types/package.json
+++ b/packages/avro-logical-types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ovotech/avro-logical-types",
   "description": "Some logical types for avsc",
-  "version": "1.0.2",
+  "version": "1.1.2",
   "main": "dist/index.js",
   "source": "src/index.ts",
   "types": "dist/index.d.ts",

--- a/packages/avro-logical-types/package.json
+++ b/packages/avro-logical-types/package.json
@@ -32,5 +32,9 @@
   },
   "jest": {
     "preset": "../../jest-preset.json"
+  },
+  "dependencies": {
+    "decimal.js": "^10.2.0",
+    "int64-buffer": "^0.99.1007"
   }
 }

--- a/packages/avro-logical-types/src/DateAsDateType.ts
+++ b/packages/avro-logical-types/src/DateAsDateType.ts
@@ -1,0 +1,20 @@
+import { Type, types } from 'avsc';
+import { toDate, fromDate } from './helpers/epoch-days';
+
+/**
+ * Custom logical type used to encode native Date objects as int.
+ */
+export class DateAsDateType extends types.LogicalType {
+  _fromValue(val: number) {
+    return toDate(val);
+  }
+  _toValue(date: any) {
+    return fromDate(date);
+  }
+  _resolve(type: any) {
+    if (Type.isType(type, 'int', 'logical:date')) {
+      return this._fromValue;
+    }
+    return undefined;
+  }
+}

--- a/packages/avro-logical-types/src/DateType.ts
+++ b/packages/avro-logical-types/src/DateType.ts
@@ -1,16 +1,15 @@
 import { Type, types } from 'avsc';
-
-const millisecondsInADay = 8.64e7;
+import { toDate, fromDate } from './helpers/epoch-days';
 
 /**
  * Custom logical type used to encode native Date objects as int.
  */
 export class DateType extends types.LogicalType {
   _fromValue(val: number) {
-    return new Date(val * millisecondsInADay).toISOString();
+    return toDate(val).toISOString();
   }
   _toValue(date: any) {
-    return date instanceof Date ? Math.floor(date.getTime() / millisecondsInADay) : date;
+    return fromDate(date);
   }
   _resolve(type: any) {
     if (Type.isType(type, 'int', 'logical:date')) {

--- a/packages/avro-logical-types/src/DecimalType.ts
+++ b/packages/avro-logical-types/src/DecimalType.ts
@@ -1,0 +1,71 @@
+import { Type, types } from 'avsc';
+import { Decimal } from 'decimal.js';
+import { Int64BE } from 'int64-buffer';
+
+export class DecimalType extends types.LogicalType {
+  public precision: number;
+  public scale: number;
+
+  constructor(schema: any, opts?: any) {
+    super(schema, opts);
+    this.precision = schema.precision;
+    this.scale = schema.scale;
+  }
+
+  public _export(attrs: any) {
+    attrs.precision = this.precision;
+    attrs.scale = this.scale;
+  }
+
+  public _resolve(type: Type) {
+    if (
+      type instanceof DecimalType &&
+      Type.isType(type, 'logical:decimal') &&
+      type.precision === this.precision &&
+      type.scale === this.scale
+    ) {
+      return <T>(x: T): T => x;
+    }
+  }
+
+  public _fromValue(buf: any) {
+    if (!(buf instanceof Buffer)) {
+      throw new Error('expecting underlying Buffer type');
+    }
+
+    if (buf.length > 8) {
+      throw new Error('buffers with more than 64bits are not supported');
+    }
+
+    return bufferToDecimal(buf, this.scale);
+  }
+
+  public _toValue(val: any) {
+    if (!(val instanceof Decimal)) {
+      throw new Error('expecting Decimal type');
+    }
+
+    return decimalToBuffer(val, this.scale);
+  }
+}
+
+export function decimalToBuffer(val: Decimal, scale: number): Buffer {
+  const scaled = val.mul(10 ** scale);
+  const value = new Int64BE(scaled.trunc().toString());
+  return value.toBuffer();
+}
+
+export function bufferToDecimal(buf: Buffer, scale: number): Decimal {
+  const unscaled = new Int64BE(to64Bit(buf));
+  return new Decimal(unscaled.toString()).div(10 ** scale);
+}
+
+export function to64Bit(buf: Buffer) {
+  // tslint:disable-next-line:no-bitwise
+  const isNegatve = buf[0] & 0x80;
+  const toFill = 8 - buf.length;
+
+  const bufferElements = Array.prototype.slice.call(buf, 0);
+
+  return Buffer.from([...[...new Array(toFill)].map(_ => (isNegatve ? 0xff : 0x00)), ...bufferElements]);
+}

--- a/packages/avro-logical-types/src/TimestampAsDateType.ts
+++ b/packages/avro-logical-types/src/TimestampAsDateType.ts
@@ -1,0 +1,18 @@
+import { Type, types } from 'avsc';
+/**
+ * Custom logical type used to encode native Date objects as long.
+ */
+export class TimestampAsDateType extends types.LogicalType {
+  _fromValue(val: number) {
+    return new Date(val);
+  }
+  _toValue(date: any) {
+    return date instanceof Date ? date.getTime() : date;
+  }
+  _resolve(type: any) {
+    if (Type.isType(type, 'long', 'logical:timestamp-millis')) {
+      return this._fromValue;
+    }
+    return undefined;
+  }
+}

--- a/packages/avro-logical-types/src/helpers/epoch-days.ts
+++ b/packages/avro-logical-types/src/helpers/epoch-days.ts
@@ -1,0 +1,4 @@
+const millisecondsInADay = 8.64e7;
+
+export const fromDate = (date: any) => (date instanceof Date ? Math.floor(date.getTime() / millisecondsInADay) : date);
+export const toDate = (val: number) => new Date(val * millisecondsInADay);

--- a/packages/avro-logical-types/src/index.ts
+++ b/packages/avro-logical-types/src/index.ts
@@ -1,2 +1,5 @@
 export { DateType } from './DateType';
+export { DateAsDateType } from './DateAsDateType';
+export { DecimalType } from './DecimalType';
 export { TimestampType } from './TimestampType';
+export { TimestampAsDateType } from './TimestampAsDateType';

--- a/packages/avro-logical-types/test/DateAsDateType.spec.ts
+++ b/packages/avro-logical-types/test/DateAsDateType.spec.ts
@@ -1,0 +1,66 @@
+import { Schema, Type } from 'avsc';
+import { DateAsDateType } from '../src';
+
+describe('Unit test', () => {
+  it('DateAsDateType', async () => {
+    const type = Type.forSchema(
+      {
+        type: 'record',
+        fields: [{ name: 'startedAt', type: { type: 'int', logicalType: 'date' } }],
+      } as Schema,
+      { logicalTypes: { date: DateAsDateType } },
+    );
+
+    const values = [{ startedAt: new Date('2018-06-05') }, { startedAt: 17687 }];
+    const expected = [
+      { startedAt: new Date('2018-06-05T00:00:00.000Z') },
+      { startedAt: new Date('2018-06-05T00:00:00.000Z') },
+    ];
+
+    const buffers = values.map(value => type.toBuffer(value));
+    const converted = buffers.map(buffer => type.fromBuffer(buffer));
+
+    expect(buffers[0]).toEqual(buffers[1]);
+    expect(converted).toEqual(expected);
+    expect(buffers).toMatchSnapshot();
+  });
+
+  it('Test resolve from int', () => {
+    const type = Type.forSchema(
+      {
+        type: 'record',
+        fields: [{ name: 'startedAt', type: { type: 'int', logicalType: 'date' } }],
+      } as Schema,
+      { logicalTypes: { date: DateAsDateType } },
+    );
+
+    const longType = Type.forSchema({
+      type: 'record',
+      fields: [{ name: 'startedAt', type: 'int' }, { name: 'name', type: 'string' }],
+    } as Schema);
+
+    const expected = { startedAt: new Date('2018-06-05T00:00:00.000Z') };
+    const longBuffer = longType.toBuffer({ startedAt: 17687, name: 'test' });
+    const resolver = type.createResolver(longType);
+    const value = type.fromBuffer(longBuffer, resolver);
+
+    expect(value).toEqual(expected);
+  });
+
+  it('Test invalid resolver', () => {
+    const type = Type.forSchema(
+      {
+        type: 'record',
+        fields: [{ name: 'startedAt', type: { type: 'int', logicalType: 'date' } }],
+      } as Schema,
+      { logicalTypes: { date: DateAsDateType } },
+    );
+
+    const longType = Type.forSchema({
+      type: 'record',
+      fields: [{ name: 'startedAt', type: 'string' }],
+    } as Schema);
+
+    expect(() => type.createResolver(longType)).toThrowError();
+  });
+});

--- a/packages/avro-logical-types/test/DecimalType.spec.ts
+++ b/packages/avro-logical-types/test/DecimalType.spec.ts
@@ -1,0 +1,75 @@
+import { Type } from 'avsc';
+import { Decimal } from 'decimal.js';
+import { bufferToDecimal, decimalToBuffer, to64Bit } from '../src/DecimalType';
+import { DecimalType } from '../src';
+
+export const decimalSchema = Type.forSchema(
+  {
+    type: 'bytes',
+    logicalType: 'decimal',
+    precision: 16,
+    scale: 8,
+  },
+  {
+    logicalTypes: { decimal: DecimalType },
+  },
+);
+
+describe('DecimalSchema', () => {
+  it('can serialise/deserialise a decimal', () => {
+    const d = new Decimal('100.01');
+    expect(d).toEqual(decimalSchema.fromBuffer(decimalSchema.toBuffer(d)));
+  });
+
+  it('truncates decimals with greater scale', () => {
+    const d = new Decimal('99999999.999999999');
+    expect(new Decimal('99999999.99999999')).toEqual(decimalSchema.fromBuffer(decimalSchema.toBuffer(d)));
+  });
+});
+
+describe('to64Bit', () => {
+  it('correctly converts the buffer for a positive number to a 64bit one', () => {
+    // buffer for number 1
+    const input = Buffer.from([0x01]);
+
+    expect(to64Bit(input).equals(Buffer.from([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01]))).toBe(true);
+  });
+
+  it('correctly converts the buffer for a negative number to a 64bit one', () => {
+    // buffer for number -1
+    const input = Buffer.from([0xff]);
+
+    expect(to64Bit(input).equals(Buffer.from([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]))).toBe(true);
+  });
+});
+
+describe('bufferToDecimal', () => {
+  it('converts any <= 8byte buffer to a decimal', () => {
+    const testOneBuffers = [
+      Buffer.from([0x01]),
+      Buffer.from([0x00, 0x01]),
+      Buffer.from([0x00, 0x00, 0x01]),
+      Buffer.from([0x00, 0x00, 0x00, 0x01]),
+      Buffer.from([0x00, 0x00, 0x00, 0x00, 0x01]),
+      Buffer.from([0x00, 0x00, 0x00, 0x00, 0x00, 0x01]),
+      Buffer.from([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01]),
+      Buffer.from([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01]),
+    ];
+
+    testOneBuffers.forEach(b => {
+      expect(bufferToDecimal(b, 0).equals('1')).toBe(true);
+      expect(bufferToDecimal(b, 4).equals('0.0001')).toBe(true);
+    });
+  });
+});
+
+describe('decimalToBuffer', () => {
+  it('converts any decimal to an 8byte buffer', () => {
+    expect(
+      decimalToBuffer(new Decimal('1'), 0).equals(Buffer.from([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01])),
+    ).toBe(true);
+    expect(
+      decimalToBuffer(new Decimal('0.0001'), 4).equals(Buffer.from([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01])),
+    ).toBe(true);
+  });
+});

--- a/packages/avro-logical-types/test/TimestampAsDateType.spec.ts
+++ b/packages/avro-logical-types/test/TimestampAsDateType.spec.ts
@@ -1,0 +1,63 @@
+import { Schema, Type } from 'avsc';
+import { TimestampType } from '../src';
+
+describe('Unit test', () => {
+  it('TimestampType convertion', async () => {
+    const type = Type.forSchema(
+      {
+        type: 'record',
+        fields: [{ name: 'startedAt', type: { type: 'long', logicalType: 'timestamp-millies' } }],
+      } as Schema,
+      { logicalTypes: { 'timestamp-millies': TimestampType } },
+    );
+
+    const values = [{ startedAt: new Date('2019-01-14T14:06:53Z') }, { startedAt: 1547474813000 }];
+    const expected = [{ startedAt: '2019-01-14T14:06:53.000Z' }, { startedAt: '2019-01-14T14:06:53.000Z' }];
+
+    const buffers = values.map(value => type.toBuffer(value));
+    const converted = buffers.map(buffer => type.fromBuffer(buffer));
+
+    expect(buffers[0]).toEqual(buffers[1]);
+    expect(converted).toEqual(expected);
+    expect(buffers).toMatchSnapshot();
+  });
+
+  it('Test resolve from long', () => {
+    const type = Type.forSchema(
+      {
+        type: 'record',
+        fields: [{ name: 'startedAt', type: { type: 'long', logicalType: 'timestamp-millies' } }],
+      } as Schema,
+      { logicalTypes: { 'timestamp-millies': TimestampType } },
+    );
+
+    const longType = Type.forSchema({
+      type: 'record',
+      fields: [{ name: 'startedAt', type: 'long' }, { name: 'name', type: 'string' }],
+    } as Schema);
+
+    const expected = { startedAt: '2019-01-14T14:06:53.000Z' };
+    const longBuffer = longType.toBuffer({ startedAt: 1547474813000, name: 'test' });
+    const resolver = type.createResolver(longType);
+    const value = type.fromBuffer(longBuffer, resolver);
+
+    expect(value).toEqual(expected);
+  });
+
+  it('Test invalid resolver', () => {
+    const type = Type.forSchema(
+      {
+        type: 'record',
+        fields: [{ name: 'startedAt', type: { type: 'long', logicalType: 'timestamp-millies' } }],
+      } as Schema,
+      { logicalTypes: { 'timestamp-millies': TimestampType } },
+    );
+
+    const longType = Type.forSchema({
+      type: 'record',
+      fields: [{ name: 'startedAt', type: 'string' }],
+    } as Schema);
+
+    expect(() => type.createResolver(longType)).toThrowError();
+  });
+});

--- a/packages/avro-logical-types/test/TimestampType.spec.ts
+++ b/packages/avro-logical-types/test/TimestampType.spec.ts
@@ -1,5 +1,5 @@
 import { Schema, Type } from 'avsc';
-import { TimestampType } from '../src';
+import { TimestampAsDateType } from '../src';
 
 describe('Unit test', () => {
   it('TimestampType convertion', async () => {
@@ -8,11 +8,11 @@ describe('Unit test', () => {
         type: 'record',
         fields: [{ name: 'startedAt', type: { type: 'long', logicalType: 'timestamp-millies' } }],
       } as Schema,
-      { logicalTypes: { 'timestamp-millies': TimestampType } },
+      { logicalTypes: { 'timestamp-millies': TimestampAsDateType } },
     );
 
     const values = [{ startedAt: new Date('2019-01-14T14:06:53Z') }, { startedAt: 1547474813000 }];
-    const expected = [{ startedAt: '2019-01-14T14:06:53.000Z' }, { startedAt: '2019-01-14T14:06:53.000Z' }];
+    const expected = [{ startedAt: new Date(1547474813000) }, { startedAt: new Date(1547474813000) }];
 
     const buffers = values.map(value => type.toBuffer(value));
     const converted = buffers.map(buffer => type.fromBuffer(buffer));
@@ -28,7 +28,7 @@ describe('Unit test', () => {
         type: 'record',
         fields: [{ name: 'startedAt', type: { type: 'long', logicalType: 'timestamp-millies' } }],
       } as Schema,
-      { logicalTypes: { 'timestamp-millies': TimestampType } },
+      { logicalTypes: { 'timestamp-millies': TimestampAsDateType } },
     );
 
     const longType = Type.forSchema({
@@ -36,7 +36,7 @@ describe('Unit test', () => {
       fields: [{ name: 'startedAt', type: 'long' }, { name: 'name', type: 'string' }],
     } as Schema);
 
-    const expected = { startedAt: '2019-01-14T14:06:53.000Z' };
+    const expected = { startedAt: new Date(1547474813000) };
     const longBuffer = longType.toBuffer({ startedAt: 1547474813000, name: 'test' });
     const resolver = type.createResolver(longType);
     const value = type.fromBuffer(longBuffer, resolver);
@@ -50,7 +50,7 @@ describe('Unit test', () => {
         type: 'record',
         fields: [{ name: 'startedAt', type: { type: 'long', logicalType: 'timestamp-millies' } }],
       } as Schema,
-      { logicalTypes: { 'timestamp-millies': TimestampType } },
+      { logicalTypes: { 'timestamp-millies': TimestampAsDateType } },
     );
 
     const longType = Type.forSchema({

--- a/packages/avro-logical-types/test/__snapshots__/DateAsDateType.spec.ts.snap
+++ b/packages/avro-logical-types/test/__snapshots__/DateAsDateType.spec.ts.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Unit test DateAsDateType 1`] = `
+Array [
+  Object {
+    "data": Array [
+      174,
+      148,
+      2,
+    ],
+    "type": "Buffer",
+  },
+  Object {
+    "data": Array [
+      174,
+      148,
+      2,
+    ],
+    "type": "Buffer",
+  },
+]
+`;

--- a/packages/avro-logical-types/test/__snapshots__/TimestampAsDateType.spec.ts.snap
+++ b/packages/avro-logical-types/test/__snapshots__/TimestampAsDateType.spec.ts.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Unit test TimestampType convertion 1`] = `
+Array [
+  Object {
+    "data": Array [
+      144,
+      129,
+      254,
+      202,
+      137,
+      90,
+    ],
+    "type": "Buffer",
+  },
+  Object {
+    "data": Array [
+      144,
+      129,
+      254,
+      202,
+      137,
+      90,
+    ],
+    "type": "Buffer",
+  },
+]
+`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2412,6 +2412,11 @@ decamelize@^1.1.0, decamelize@^1.1.2, decamelize@^1.2.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
 
+decimal.js@^10.2.0:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.2.0.tgz#39466113a9e036111d02f82489b5fd6b0b5ed231"
+  integrity sha512-vDPw+rDgn3bZe1+F/pyEwb1oMG2XTlRVgAa6B4KccTEpYgF8w6eQllVbQcfIJnZyvzFtFpxnpGtx8dd7DJp/Rw==
+
 decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
@@ -3501,6 +3506,11 @@ inquirer@^6.2.0:
     string-width "^2.1.0"
     strip-ansi "^5.0.0"
     through "^2.3.6"
+
+int64-buffer@^0.99.1007:
+  version "0.99.1007"
+  resolved "https://registry.yarnpkg.com/int64-buffer/-/int64-buffer-0.99.1007.tgz#211ea089a2fdb960070a2e77cd6d17dc456a5220"
+  integrity sha512-XDBEu44oSTqlvCSiOZ/0FoUkpWu/vwjJLGSKDabNISPQNZ5wub1FodGHBljRsrR0IXRPq7SslshZYMuA55CgTQ==
 
 invariant@^2.2.4:
   version "2.2.4"


### PR DESCRIPTION
:wave: Hellooo!

This is largely a copy/paste of the logical types we're using in our team and I figured it would better sit in here than in a new open source library.

I'm a bit sad I had to create a duplicates of `DateType` and `TimestampType` to avoid the `toISOString` but I'm not sure there's an alternative given how `avsc` [instantiates the classes](https://github.com/mtth/avsc/blob/944a530ac628f89c1827dd2fd3c97b35668fa796/lib/types.js#L190). Suggestion welcome on this.
