### PR TITLE
Do not include credentials in error if registry returns invalid JSON

### DIFF
--- a/packages/schema-registry-api/package.json
+++ b/packages/schema-registry-api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ovotech/schema-registry-api",
   "description": "A simple typescript node-fetch wrapper on the confluent schema-registry api",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "main": "dist/index.js",
   "source": "src/index.ts",
   "types": "dist/index.d.ts",

--- a/packages/schema-registry-api/src/api.ts
+++ b/packages/schema-registry-api/src/api.ts
@@ -33,7 +33,14 @@ const apiFetch = async <T>(req: string | Request, init: RequestInit = {}): Promi
     },
   };
   const res = await fetch(req, { ...defaultInit, ...init });
-  const data = await res.json();
+  let data;
+  try {
+    data = await res.json();
+  } catch (e) {
+    // Generic error to avoid including URL in message, as it may contain
+    // sensitive credentials.
+    throw TypeError('Schema registry responded with invalid JSON.');
+  }
   if (!res.ok) {
     throw new SchemaRegistryError(data.message, data.error_code);
   } else {

--- a/packages/schema-registry-api/src/api.ts
+++ b/packages/schema-registry-api/src/api.ts
@@ -36,7 +36,7 @@ const apiFetch = async <T>(req: string | Request, init: RequestInit = {}): Promi
   let data;
   try {
     data = await res.json();
-  } catch (e) {
+  } catch (error) {
     // Generic error to avoid including URL in message, as it may contain
     // sensitive credentials.
     throw TypeError('Schema registry responded with invalid JSON.');

--- a/packages/schema-registry-api/test/integration.spec.ts
+++ b/packages/schema-registry-api/test/integration.spec.ts
@@ -123,8 +123,9 @@ describe('Integration test', () => {
     const createdSchema = await getSchema(baseUrl, createdId);
     expect(createdSchema).toEqual({ schema: JSON.stringify(schema2) });
 
-    const normalError = schemaToId('http://example.com', subject, schema1);
-    await expect(normalError).rejects.toEqual(expect.any(FetchError));
+    const notASchemaRegistryUrl = 'http://github.com';
+    const normalError = schemaToId(notASchemaRegistryUrl, subject, schema1);
+    await expect(normalError).rejects.toEqual(expect.any(TypeError));
 
     const incompatibleSchema = schemaToId(baseUrl, subject, schema1);
     await expect(incompatibleSchema).rejects.toEqual(


### PR DESCRIPTION
If the Schema Registry returns an invalid response, this library would previously throw a `FetchError` which contained the full Schema Registry URL. If HTTP basic auth is being used with the registry, this URL will contain the client username and password. This can lead to sensitive credentials being stored in logs and other error outputs.

This commit fixes the issue by throwing a TypeError with a generic message instead.