### PR TITLE
Don't wait for async functions to finish.

### DIFF
--- a/packages/influx-metrics-tracker/package.json
+++ b/packages/influx-metrics-tracker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ovotech/influx-metrics-tracker",
   "description": "Track metrics and store them in an Influx database, with secondary logging if Influx is unavailable",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "main": "dist/index.js",
   "source": "src/index.ts",
   "types": "dist/index.d.ts",

--- a/packages/influx-metrics-tracker/src/base.ts
+++ b/packages/influx-metrics-tracker/src/base.ts
@@ -10,7 +10,7 @@ export abstract class MetricsTracker {
     },
   ) {}
 
-  protected async trackPoint(
+  protected trackPoint(
     measurementName: string,
     tags: { [name: string]: string },
     fields: { [name: string]: any },
@@ -18,24 +18,22 @@ export abstract class MetricsTracker {
     const validTags = this.getValidTags(tags);
     this.logInvalidTags(measurementName, tags);
 
-    try {
-      await this.influx.writePoints([
-        {
-          measurement: measurementName,
-          tags: {
-            ...this.staticMeta,
-            ...validTags,
-          },
-          fields,
+    this.influx.writePoints([
+      {
+        measurement: measurementName,
+        tags: {
+          ...this.staticMeta,
+          ...validTags,
         },
-      ]);
-    } catch (err) {
+        fields,
+      },
+    ]).catch(err => {
       this.logger.error('Error tracking Influx metric', {
         metric: measurementName,
         tags: JSON.stringify(validTags),
         fields: JSON.stringify(fields),
       });
-    }
+    })
   }
 
   private getInvalidTagNames(tags: { [name: string]: string }) {

--- a/packages/influx-metrics-tracker/src/external-request.ts
+++ b/packages/influx-metrics-tracker/src/external-request.ts
@@ -3,8 +3,8 @@ import { MetricsTracker } from './base';
 export class ExternalRequestMetricsTracker extends MetricsTracker {
   private static externalRequestTimeMeasurementName = 'external-request-time';
 
-  async trackRequestTime(externalServiceName: string, requestName: string, timeMs: number, statusCode?: number) {
-    await this.trackPoint(
+  trackRequestTime(externalServiceName: string, requestName: string, timeMs: number, statusCode?: number) {
+    this.trackPoint(
       ExternalRequestMetricsTracker.externalRequestTimeMeasurementName,
       { requestName, externalServiceName, status: statusCode ? statusCode.toString() : '' },
       { timeMs: Math.round(timeMs), count: 1 },

--- a/packages/influx-metrics-tracker/src/kafka.ts
+++ b/packages/influx-metrics-tracker/src/kafka.ts
@@ -4,8 +4,8 @@ export class KafkaMetricsTracker extends MetricsTracker {
   private static eventProcessedMeasurementName = 'kafka-event-processed';
   private static eventReceivedMeasurementName = 'kafka-event-received';
 
-  async trackEventReceived(eventName: string, ageMs: number) {
-    await this.trackPoint(
+  trackEventReceived(eventName: string, ageMs: number) {
+    this.trackPoint(
       KafkaMetricsTracker.eventReceivedMeasurementName,
       { eventName },
       { count: 1, ageMs: Math.round(ageMs) },
@@ -13,7 +13,7 @@ export class KafkaMetricsTracker extends MetricsTracker {
   }
 
   async trackEventProcessed(eventName: string, processingState: ProcessingState) {
-    await this.trackPoint(
+    this.trackPoint(
       KafkaMetricsTracker.eventProcessedMeasurementName,
       { eventName, processingState },
       { count: 1 },

--- a/packages/influx-metrics-tracker/src/response.ts
+++ b/packages/influx-metrics-tracker/src/response.ts
@@ -3,8 +3,8 @@ import { MetricsTracker } from './base';
 export class ResponseMetricsTracker extends MetricsTracker {
   private static ownResponseTimeMeasurementName = 'own-response-time';
 
-  async trackOwnResponseTime(requestName: string, timeMs: number, statusCode?: number) {
-    await this.trackPoint(
+  trackOwnResponseTime(requestName: string, timeMs: number, statusCode?: number) {
+    this.trackPoint(
       ResponseMetricsTracker.ownResponseTimeMeasurementName,
       { requestName, status: statusCode ? statusCode.toString() : '' },
       { timeMs: Math.round(timeMs), count: 1 },


### PR DESCRIPTION
I think that by using `await` in front of the influx calls, it will block execution until the request is complete. If influx is overloaded, this may slow services that use this down.

By catching the promise instead, I believe it will complete out of the "event loop"