### PR TITLE
Revert async influx change

### DIFF
--- a/packages/influx-metrics-tracker/package.json
+++ b/packages/influx-metrics-tracker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ovotech/influx-metrics-tracker",
   "description": "Track metrics and store them in an Influx database, with secondary logging if Influx is unavailable",
-  "version": "1.1.3",
+  "version": "1.1.2",
   "main": "dist/index.js",
   "source": "src/index.ts",
   "types": "dist/index.d.ts",

--- a/packages/influx-metrics-tracker/package.json
+++ b/packages/influx-metrics-tracker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ovotech/influx-metrics-tracker",
   "description": "Track metrics and store them in an Influx database, with secondary logging if Influx is unavailable",
-  "version": "1.1.2",
+  "version": "1.1.4",
   "main": "dist/index.js",
   "source": "src/index.ts",
   "types": "dist/index.d.ts",

--- a/packages/influx-metrics-tracker/src/base.ts
+++ b/packages/influx-metrics-tracker/src/base.ts
@@ -10,7 +10,7 @@ export abstract class MetricsTracker {
     },
   ) {}
 
-  protected trackPoint(
+  protected async trackPoint(
     measurementName: string,
     tags: { [name: string]: string },
     fields: { [name: string]: any },
@@ -18,22 +18,24 @@ export abstract class MetricsTracker {
     const validTags = this.getValidTags(tags);
     this.logInvalidTags(measurementName, tags);
 
-    this.influx.writePoints([
-      {
-        measurement: measurementName,
-        tags: {
-          ...this.staticMeta,
-          ...validTags,
+    try {
+      await this.influx.writePoints([
+        {
+          measurement: measurementName,
+          tags: {
+            ...this.staticMeta,
+            ...validTags,
+          },
+          fields,
         },
-        fields,
-      },
-    ]).catch(err => {
+      ]);
+    } catch (err) {
       this.logger.error('Error tracking Influx metric', {
         metric: measurementName,
         tags: JSON.stringify(validTags),
         fields: JSON.stringify(fields),
       });
-    })
+    }
   }
 
   private getInvalidTagNames(tags: { [name: string]: string }) {

--- a/packages/influx-metrics-tracker/src/external-request.ts
+++ b/packages/influx-metrics-tracker/src/external-request.ts
@@ -3,8 +3,8 @@ import { MetricsTracker } from './base';
 export class ExternalRequestMetricsTracker extends MetricsTracker {
   private static externalRequestTimeMeasurementName = 'external-request-time';
 
-  trackRequestTime(externalServiceName: string, requestName: string, timeMs: number, statusCode?: number) {
-    this.trackPoint(
+  async trackRequestTime(externalServiceName: string, requestName: string, timeMs: number, statusCode?: number) {
+    await this.trackPoint(
       ExternalRequestMetricsTracker.externalRequestTimeMeasurementName,
       { requestName, externalServiceName, status: statusCode ? statusCode.toString() : '' },
       { timeMs: Math.round(timeMs), count: 1 },

--- a/packages/influx-metrics-tracker/src/kafka.ts
+++ b/packages/influx-metrics-tracker/src/kafka.ts
@@ -4,8 +4,8 @@ export class KafkaMetricsTracker extends MetricsTracker {
   private static eventProcessedMeasurementName = 'kafka-event-processed';
   private static eventReceivedMeasurementName = 'kafka-event-received';
 
-  trackEventReceived(eventName: string, ageMs: number) {
-    this.trackPoint(
+  async trackEventReceived(eventName: string, ageMs: number) {
+    await this.trackPoint(
       KafkaMetricsTracker.eventReceivedMeasurementName,
       { eventName },
       { count: 1, ageMs: Math.round(ageMs) },
@@ -13,7 +13,7 @@ export class KafkaMetricsTracker extends MetricsTracker {
   }
 
   async trackEventProcessed(eventName: string, processingState: ProcessingState) {
-    this.trackPoint(
+    await this.trackPoint(
       KafkaMetricsTracker.eventProcessedMeasurementName,
       { eventName, processingState },
       { count: 1 },

--- a/packages/influx-metrics-tracker/src/response.ts
+++ b/packages/influx-metrics-tracker/src/response.ts
@@ -3,8 +3,8 @@ import { MetricsTracker } from './base';
 export class ResponseMetricsTracker extends MetricsTracker {
   private static ownResponseTimeMeasurementName = 'own-response-time';
 
-  trackOwnResponseTime(requestName: string, timeMs: number, statusCode?: number) {
-    this.trackPoint(
+  async trackOwnResponseTime(requestName: string, timeMs: number, statusCode?: number) {
+    await this.trackPoint(
       ResponseMetricsTracker.ownResponseTimeMeasurementName,
       { requestName, status: statusCode ? statusCode.toString() : '' },
       { timeMs: Math.round(timeMs), count: 1 },


### PR DESCRIPTION
This PR reverts the changes to https://github.com/ovotech/bit-node-tools/pull/63 and bumps the version number

This was done in a panic when the Boost portal was being unresponsive. There were lots of logs about Influx not connecting, the Influx metric package was returning a promise from its calls, which left the possibility that a calling service might wait for the Influx request to complete, which might lead to unresponsiveness if the Influx service was unavailable. As it turns out, hardly any calls were waiting for the promise to complete.

The PR stopped returning a promise from an Influx metrics call so it couldn't be waited for. Changing the influx types means a changing a **lot** of types in the calling services for not a lot of gain