### PR TITLE
Improved batch call logs

### DIFF
--- a/packages/influx-metrics-tracker/package.json
+++ b/packages/influx-metrics-tracker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ovotech/influx-metrics-tracker",
   "description": "Track metrics and store them in an Influx database, with secondary logging if Influx is unavailable",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "main": "dist/index.js",
   "source": "src/index.ts",
   "types": "dist/index.d.ts",

--- a/packages/influx-metrics-tracker/package.json
+++ b/packages/influx-metrics-tracker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ovotech/influx-metrics-tracker",
   "description": "Track metrics and store them in an Influx database, with secondary logging if Influx is unavailable",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "main": "dist/index.js",
   "source": "src/index.ts",
   "types": "dist/index.d.ts",

--- a/packages/influx-metrics-tracker/src/base.ts
+++ b/packages/influx-metrics-tracker/src/base.ts
@@ -22,8 +22,7 @@ export abstract class MetricsTracker {
     protected batchSendIntervalMs = ONE_MINUTE,
   ) {
     this.sendPointsToInflux = this.sendPointsToInflux.bind(this);
-    this.batchCalls =
-      batchCalls || getBatchCallsInstance(this.batchSendIntervalMs, this.sendPointsToInflux, this.logger);
+    this.batchCalls = batchCalls || getBatchCallsInstance(this.sendPointsToInflux, this.logger);
   }
 
   protected async trackPoint(

--- a/packages/influx-metrics-tracker/src/base.ts
+++ b/packages/influx-metrics-tracker/src/base.ts
@@ -21,7 +21,6 @@ export abstract class MetricsTracker {
     protected batchCalls?: BatchCalls,
     protected batchSendIntervalMs = ONE_MINUTE,
   ) {
-    this.logger.info('Instantiated new Metrics Tracker');
     this.sendPointsToInflux = this.sendPointsToInflux.bind(this);
     this.batchCalls =
       batchCalls || getBatchCallsInstance(this.batchSendIntervalMs, this.sendPointsToInflux, this.logger);

--- a/packages/influx-metrics-tracker/src/helpers/batch-calls.ts
+++ b/packages/influx-metrics-tracker/src/helpers/batch-calls.ts
@@ -3,11 +3,7 @@ import { Logger } from '@ovotech/winston-logger';
 export class BatchCalls {
   private batchData: unknown[];
 
-  constructor(
-    protected batchSendIntervalMs: number,
-    private callback: (...args: any[]) => void,
-    protected logger: Logger,
-  ) {
+  constructor(private callback: (...args: any[]) => void, protected logger: Logger) {
     this.batchData = [];
   }
 
@@ -40,31 +36,22 @@ export class BatchCalls {
 
 interface Instance {
   classInstance: BatchCalls;
-  batchSendIntervalMs: number;
   callback: (...args: any[]) => void;
   logger: Logger;
 }
 
 const currentInstances: Instance[] = [];
 
-export default function getBatchCallsInstance(
-  batchSendIntervalMs: number,
-  callback: (...args: any[]) => void,
-  logger: Logger,
-): BatchCalls {
+export default function getBatchCallsInstance(callback: (...args: any[]) => void, logger: Logger): BatchCalls {
   let foundInstance = currentInstances.find(
-    currentInstance =>
-      currentInstance.batchSendIntervalMs === batchSendIntervalMs &&
-      currentInstance.callback === callback &&
-      currentInstance.logger === logger,
+    currentInstance => currentInstance.callback === callback && currentInstance.logger === logger,
   );
 
   if (!foundInstance) {
     logger.info('Instantiating new Influx Batch Calls class instance');
 
     foundInstance = {
-      classInstance: new BatchCalls(batchSendIntervalMs, callback, logger),
-      batchSendIntervalMs,
+      classInstance: new BatchCalls(callback, logger),
       callback,
       logger,
     };

--- a/packages/influx-metrics-tracker/src/helpers/batch-calls.ts
+++ b/packages/influx-metrics-tracker/src/helpers/batch-calls.ts
@@ -63,6 +63,8 @@ export default function getBatchCallsInstance(
   );
 
   if (!foundInstance) {
+    logger.info('Instantiating new Influx Batch Calls class instance');
+
     foundInstance = {
       classInstance: new BatchCalls(batchSendIntervalMs, callback, logger),
       batchSendIntervalMs,

--- a/packages/influx-metrics-tracker/src/helpers/batch-calls.ts
+++ b/packages/influx-metrics-tracker/src/helpers/batch-calls.ts
@@ -9,14 +9,19 @@ export class BatchCalls {
     protected logger: Logger,
   ) {
     this.batchData = [];
-    this.startBatchEventLoop(batchSendIntervalMs);
   }
 
-  public addToBatch(item: unknown) {
+  public async addToBatch(item: unknown) {
     this.batchData.push(item);
+
+    if (this.batchData.length >= 50) {
+      const tempBatchData = [...this.batchData];
+      this.flushBatchData();
+      await this.executeCallbackForBatch(tempBatchData);
+    }
   }
 
-  private async sendBatches(batchData: unknown[]) {
+  private async executeCallbackForBatch(batchData: unknown[]) {
     if (batchData.length > 0) {
       try {
         return this.callback(batchData);
@@ -30,14 +35,6 @@ export class BatchCalls {
 
   private flushBatchData() {
     this.batchData = [];
-  }
-
-  private startBatchEventLoop(batchSendIntervalMs: number) {
-    setInterval(async () => {
-      const tempBatchData = [...this.batchData];
-      this.flushBatchData();
-      await this.sendBatches(tempBatchData);
-    }, batchSendIntervalMs);
   }
 }
 

--- a/packages/influx-metrics-tracker/test/helpers/batch-calls.spec.ts
+++ b/packages/influx-metrics-tracker/test/helpers/batch-calls.spec.ts
@@ -17,10 +17,10 @@ describe('BatchCalls', () => {
   });
 
   it('Does not create any new class instances but instead returns the same singleton class', () => {
-    const firstInstance = getBatchCallsInstance(1000, mockFunction, mockLogger);
-    const secondInstance = getBatchCallsInstance(1000, mockFunction, mockLogger);
-    const thirdInstance = getBatchCallsInstance(1000, mockFunction, mockLogger);
-    const fourthInstance = getBatchCallsInstance(1000, mockFunction, mockLogger);
+    const firstInstance = getBatchCallsInstance(mockFunction, mockLogger);
+    const secondInstance = getBatchCallsInstance(mockFunction, mockLogger);
+    const thirdInstance = getBatchCallsInstance(mockFunction, mockLogger);
+    const fourthInstance = getBatchCallsInstance(mockFunction, mockLogger);
 
     expect(firstInstance).toBe(secondInstance);
     expect(secondInstance).toBe(thirdInstance);
@@ -28,23 +28,25 @@ describe('BatchCalls', () => {
   });
 
   it('Creates a new instance of a class if the second instance has different parameters', () => {
-    const firstInstance = getBatchCallsInstance(1000, mockFunction, mockLogger);
-    const secondInstance = getBatchCallsInstance(2000, mockFunction, mockLogger);
+    const anotherMockFunction = jest.fn().mockReturnValue('blaa');
+    const firstInstance = getBatchCallsInstance(mockFunction, mockLogger);
+    const secondInstance = getBatchCallsInstance(anotherMockFunction, mockLogger);
 
     expect(firstInstance).not.toBe(secondInstance);
   });
 
   it('Returns the correct instance of a class if it has the same parameters', () => {
-    const firstInstance = getBatchCallsInstance(1000, mockFunction, mockLogger);
-    const secondInstance = getBatchCallsInstance(2000, mockFunction, mockLogger);
-    const thirdInstance = getBatchCallsInstance(1000, mockFunction, mockLogger);
+    const anotherMockFunction = jest.fn().mockReturnValue('blaa');
+    const firstInstance = getBatchCallsInstance(mockFunction, mockLogger);
+    const secondInstance = getBatchCallsInstance(anotherMockFunction, mockLogger);
+    const thirdInstance = getBatchCallsInstance(mockFunction, mockLogger);
 
     expect(thirdInstance).toBe(firstInstance);
     expect(thirdInstance).not.toBe(secondInstance);
   });
 
   it('Calls the given function when 50 items are in the batch', () => {
-    const batchCalls = getBatchCallsInstance(1000, mockFunction, mockLogger);
+    const batchCalls = getBatchCallsInstance(mockFunction, mockLogger);
     let expected = [];
 
     for (let i = 0; i < 50; i++) {
@@ -57,7 +59,7 @@ describe('BatchCalls', () => {
   });
 
   it('Calls the given function twice when 100 identical items are in the batch', () => {
-    const batchCalls = getBatchCallsInstance(1000, mockFunction, mockLogger);
+    const batchCalls = getBatchCallsInstance(mockFunction, mockLogger);
     let expected = [];
 
     for (let i = 0; i < 100; i++) {
@@ -73,7 +75,7 @@ describe('BatchCalls', () => {
   });
 
   it('Calls the given function twice when 100 different items are in the batch', () => {
-    const batchCalls = getBatchCallsInstance(1000, mockFunction, mockLogger);
+    const batchCalls = getBatchCallsInstance(mockFunction, mockLogger);
     let firstExpectedResult = [];
     let secondExpectedResult = [];
 
@@ -91,7 +93,7 @@ describe('BatchCalls', () => {
   });
 
   it('Calls the given function once with 50 items when there is more than 50 items but less than 100 items in the batch', () => {
-    const batchCalls = getBatchCallsInstance(1000, mockFunction, mockLogger);
+    const batchCalls = getBatchCallsInstance(mockFunction, mockLogger);
     let expected = [];
 
     for (let i = 0; i < 67; i++) {
@@ -106,7 +108,7 @@ describe('BatchCalls', () => {
   });
 
   it('Does not call the given function when less than 50 items are in the batch', () => {
-    const batchCalls = getBatchCallsInstance(1000, mockFunction, mockLogger);
+    const batchCalls = getBatchCallsInstance(mockFunction, mockLogger);
     let expected = [];
 
     for (let i = 0; i < 16; i++) {


### PR DESCRIPTION
Moving from sending points to Influx every minute to sending them when the amount of data to send is of a certain size (in this case it will send points to Influx when there are 50 points in the batch). This means that the batch sizes will be much more consistent and should hopefully fix the timeout issue we're seeing on Influx.