### PR TITLE
 Bug/ae 675 batch calls

### DIFF
--- a/packages/influx-metrics-tracker/package.json
+++ b/packages/influx-metrics-tracker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ovotech/influx-metrics-tracker",
   "description": "Track metrics and store them in an Influx database, with secondary logging if Influx is unavailable",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "main": "dist/index.js",
   "source": "src/index.ts",
   "types": "dist/index.d.ts",

--- a/packages/influx-metrics-tracker/src/base.ts
+++ b/packages/influx-metrics-tracker/src/base.ts
@@ -1,6 +1,6 @@
 import { Logger } from '@ovotech/winston-logger';
 import { InfluxDB } from 'influx';
-import getBatchCallsInstance, { BatchCalls } from './helpers/batch-calls';
+import BatchCalls from './helpers/batch-calls';
 import { executeCallbackOrExponentiallyBackOff } from './helpers/exponential-backoff';
 
 const ONE_MINUTE = 60000;
@@ -22,7 +22,7 @@ export abstract class MetricsTracker {
     protected batchSendIntervalMs = ONE_MINUTE,
   ) {
     this.sendPointsToInflux = this.sendPointsToInflux.bind(this);
-    this.batchCalls = batchCalls || getBatchCallsInstance(this.sendPointsToInflux, this.logger);
+    this.batchCalls = batchCalls || new BatchCalls(this.sendPointsToInflux);
   }
 
   protected async trackPoint(

--- a/packages/influx-metrics-tracker/src/helpers/batch-calls.ts
+++ b/packages/influx-metrics-tracker/src/helpers/batch-calls.ts
@@ -3,7 +3,7 @@ import { Logger } from '@ovotech/winston-logger';
 export class BatchCalls {
   private batchData: unknown[];
 
-  constructor(private callback: (...args: any[]) => void, protected logger: Logger) {
+  constructor(private callback: (...args: any[]) => void) {
     this.batchData = [];
   }
 
@@ -19,13 +19,7 @@ export class BatchCalls {
 
   private async executeCallbackForBatch(batchData: unknown[]) {
     if (batchData.length > 0) {
-      try {
-        return this.callback(batchData);
-      } catch (error) {
-        this.logger.error('Error sending batch call to external service', {
-          error: error && error.message ? error.message : 'Unknown error',
-        });
-      }
+      return this.callback(batchData);
     }
   }
 
@@ -37,23 +31,19 @@ export class BatchCalls {
 interface Instance {
   classInstance: BatchCalls;
   callback: (...args: any[]) => void;
-  logger: Logger;
 }
 
 const currentInstances: Instance[] = [];
 
 export default function getBatchCallsInstance(callback: (...args: any[]) => void, logger: Logger): BatchCalls {
-  let foundInstance = currentInstances.find(
-    currentInstance => currentInstance.callback === callback && currentInstance.logger === logger,
-  );
+  let foundInstance = currentInstances.find(currentInstance => currentInstance.callback === callback);
 
   if (!foundInstance) {
     logger.info('Instantiating new Influx Batch Calls class instance');
 
     foundInstance = {
-      classInstance: new BatchCalls(callback, logger),
+      classInstance: new BatchCalls(callback),
       callback,
-      logger,
     };
     currentInstances.push(foundInstance);
   }

--- a/packages/influx-metrics-tracker/test/helpers/batch-calls.spec.ts
+++ b/packages/influx-metrics-tracker/test/helpers/batch-calls.spec.ts
@@ -86,7 +86,7 @@ describe('BatchCalls', () => {
     expect(mockFunction).not.toBeCalled();
   });
 
-  it('Adds to the same batch even when the data is added to two different BatchCalls instatiations', () => {
+  it('Adds to the same batch even when the data is added to two different BatchCalls instantiations', () => {
     const batchCalls = new BatchCalls(mockFunction, batchManagement);
     const batchCalls2 = new BatchCalls(mockFunction, batchManagement);
     let expectedResult = [];

--- a/packages/influx-metrics-tracker/test/helpers/batch-calls.spec.ts
+++ b/packages/influx-metrics-tracker/test/helpers/batch-calls.spec.ts
@@ -1,52 +1,20 @@
-import getBatchCallsInstance from '../../src/helpers/batch-calls';
+import BatchCalls, { BatchManagement } from '../../src/helpers/batch-calls';
 
 let mockFunction = jest.fn();
 jest.useFakeTimers();
 jest.spyOn(global, 'setTimeout');
 
 describe('BatchCalls', () => {
-  let mockLogger: any;
-
-  beforeEach(() => {
-    mockLogger = { error: jest.fn(), warn: jest.fn(), info: jest.fn() };
-  });
+  let batchManagement: BatchManagement;
 
   beforeEach(() => {
     jest.clearAllMocks();
     mockFunction = jest.fn();
-  });
-
-  it('Does not create any new class instances but instead returns the same singleton class', () => {
-    const firstInstance = getBatchCallsInstance(mockFunction, mockLogger);
-    const secondInstance = getBatchCallsInstance(mockFunction, mockLogger);
-    const thirdInstance = getBatchCallsInstance(mockFunction, mockLogger);
-    const fourthInstance = getBatchCallsInstance(mockFunction, mockLogger);
-
-    expect(firstInstance).toBe(secondInstance);
-    expect(secondInstance).toBe(thirdInstance);
-    expect(thirdInstance).toBe(fourthInstance);
-  });
-
-  it('Creates a new instance of a class if the second instance has different parameters', () => {
-    const anotherMockFunction = jest.fn().mockReturnValue('blaa');
-    const firstInstance = getBatchCallsInstance(mockFunction, mockLogger);
-    const secondInstance = getBatchCallsInstance(anotherMockFunction, mockLogger);
-
-    expect(firstInstance).not.toBe(secondInstance);
-  });
-
-  it('Returns the correct instance of a class if it has the same parameters', () => {
-    const anotherMockFunction = jest.fn().mockReturnValue('blaa');
-    const firstInstance = getBatchCallsInstance(mockFunction, mockLogger);
-    const secondInstance = getBatchCallsInstance(anotherMockFunction, mockLogger);
-    const thirdInstance = getBatchCallsInstance(mockFunction, mockLogger);
-
-    expect(thirdInstance).toBe(firstInstance);
-    expect(thirdInstance).not.toBe(secondInstance);
+    batchManagement = new BatchManagement();
   });
 
   it('Calls the given function when 50 items are in the batch', () => {
-    const batchCalls = getBatchCallsInstance(mockFunction, mockLogger);
+    const batchCalls = new BatchCalls(mockFunction, batchManagement);
     let expected = [];
 
     for (let i = 0; i < 50; i++) {
@@ -59,7 +27,7 @@ describe('BatchCalls', () => {
   });
 
   it('Calls the given function twice when 100 identical items are in the batch', () => {
-    const batchCalls = getBatchCallsInstance(mockFunction, mockLogger);
+    const batchCalls = new BatchCalls(mockFunction, batchManagement);
     let expected = [];
 
     for (let i = 0; i < 100; i++) {
@@ -75,7 +43,7 @@ describe('BatchCalls', () => {
   });
 
   it('Calls the given function twice when 100 different items are in the batch', () => {
-    const batchCalls = getBatchCallsInstance(mockFunction, mockLogger);
+    const batchCalls = new BatchCalls(mockFunction, batchManagement);
     let firstExpectedResult = [];
     let secondExpectedResult = [];
 
@@ -93,7 +61,7 @@ describe('BatchCalls', () => {
   });
 
   it('Calls the given function once with 50 items when there is more than 50 items but less than 100 items in the batch', () => {
-    const batchCalls = getBatchCallsInstance(mockFunction, mockLogger);
+    const batchCalls = new BatchCalls(mockFunction, batchManagement);
     let expected = [];
 
     for (let i = 0; i < 67; i++) {
@@ -108,13 +76,34 @@ describe('BatchCalls', () => {
   });
 
   it('Does not call the given function when less than 50 items are in the batch', () => {
-    const batchCalls = getBatchCallsInstance(mockFunction, mockLogger);
-    let expected = [];
+    const batchManagement = new BatchManagement();
+    const batchCalls = new BatchCalls(mockFunction, batchManagement);
 
     for (let i = 0; i < 16; i++) {
       batchCalls.addToBatch({ data: 'its here yesss' });
     }
 
     expect(mockFunction).not.toBeCalled();
+  });
+
+  it('Adds to the same batch even when the data is added to two different BatchCalls instatiations', () => {
+    const batchCalls = new BatchCalls(mockFunction, batchManagement);
+    const batchCalls2 = new BatchCalls(mockFunction, batchManagement);
+    let expectedResult = [];
+
+    for (let i = 0; i < 25; i++) {
+      batchCalls.addToBatch({ data: `its here yesss ${i}` });
+    }
+
+    for (let i = 25; i < 50; i++) {
+      batchCalls2.addToBatch({ data: `its here yesss ${i}` });
+    }
+
+    for (let i = 0; i < 50; i++) {
+      expectedResult.push({ data: `its here yesss ${i}` });
+    }
+
+    expect(mockFunction).toBeCalledTimes(1);
+    expect(mockFunction).toHaveBeenCalledWith(expectedResult);
   });
 });


### PR DESCRIPTION
Before we weren't properly using the singleton class. It would check if the class constructor parameters were the same and if they were it would return any class that was already instantiated. However, because the logger and callback function parameters technically were not the same since they came from separate instantiations of the parent class then it would instantiate a new class each time. I've extracted the singleton logic into its own class with no parameters so it works like a true singleton