### PR TITLE
docs: Add catalog-info.yaml (generated)

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -14,4 +14,3 @@ spec:
   type: library
   lifecycle: production
   owner: retail-payg
-  system: bit-node-tools

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: System
+metadata:
+  name: bit-node-tools
+  description: Misc node tools from the Boost Internal Tools team
+  annotations:
+    github.com/project-slug: ovotech/bit-node-tools
+spec:
+  owner: boost-bit
+  domain: infrastructure-and-enablement
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: bit-node-tools
+  description: Misc node tools from the Boost Internal Tools team
+  annotations:
+    github.com/project-slug: ovotech/bit-node-tools
+    backstage.io/source-location: url:https://github.com/ovotech/bit-node-tools/tree/main
+  tags:
+    - internal
+    - typescript
+spec:
+  type: service
+  lifecycle: production
+  owner: boost-bit
+  system: bit-node-tools

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,16 +1,5 @@
 ---
 apiVersion: backstage.io/v1alpha1
-kind: System
-metadata:
-  name: bit-node-tools
-  description: Misc node tools from the Boost Internal Tools team
-  annotations:
-    github.com/project-slug: ovotech/bit-node-tools
-spec:
-  owner: boost-bit
-  domain: infrastructure-and-enablement
----
-apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: bit-node-tools
@@ -22,7 +11,7 @@ metadata:
     - internal
     - typescript
 spec:
-  type: service
+  type: library
   lifecycle: production
-  owner: boost-bit
+  owner: retail-payg
   system: bit-node-tools


### PR DESCRIPTION
This PR adds a `catalog-info.yaml` file generated with the help of Claude.

**Please review and amend, then merge** — the generated content is based on Compass, Confluence, and GitHub metadata and will likely need adjustments.

See the [Software Catalogue guide](https://developer.ovotech.org.uk/catalog/default/component/tech-handbook/docs/guides/software-catalogue/) and [standard](https://developer.ovotech.org.uk/catalog/default/component/tech-handbook/docs/standards/software-catalogue/) for more information.

Main things to check:

- System and Component names are sensible / correct
- Owner (team) names are GitHub team slugs and exist
- Libraries weren't detected very well by Claude, so you may need to adjust the Component type to `library`, and remove a System if specified.

Quick cheat sheet:

- *Component* (aka Service) - an individual piece of software. An observable unit, i.e. the thing you want to monitor and debug.
- *System* - a collection of one or more Components. A deployable unit, i.e. if you deploy multiple Components at the same time they are all the same System.

Once merged, you should see your metadata appear in Datadog (it may not appear in Switchboard - further work is required there).

If you have any problems or questions, please reach out in the [Architecture space](https://chat.google.com/room/AAQAtiuwa64?cls=7) or to Andy Raines.